### PR TITLE
Fix timing of LESS file compiling

### DIFF
--- a/sbt-plugins/sbt-shared-ui/example/project/plugins.sbt
+++ b/sbt-plugins/sbt-shared-ui/example/project/plugins.sbt
@@ -12,4 +12,4 @@ resolvers += "AllenAI Snapshots" at nexus("snapshots")
 
 resolvers += "AllenAI Releases" at nexus("releases")
 
-addSbtPlugin("org.allenai.plugins" % "sbt-shared-ui" % "0.2.3-SNAPSHOT")
+addSbtPlugin("org.allenai.plugins" % "sbt-shared-ui" % "0.2.4-SNAPSHOT")

--- a/sbt-plugins/sbt-shared-ui/example/shared/src/main/assets/less/shared.less
+++ b/sbt-plugins/sbt-shared-ui/example/shared/src/main/assets/less/shared.less
@@ -1,6 +1,6 @@
 @import "colors.less";
 
 body {
-	background-color: @bg-color;
-	color: @color;
+  background-color: @bg-color;
+  color: @color;
 }

--- a/sbt-plugins/sbt-shared-ui/example/ui1/src/main/assets/js/ui1.js
+++ b/sbt-plugins/sbt-shared-ui/example/ui1/src/main/assets/js/ui1.js
@@ -1,8 +1,7 @@
-
 var h = "hi";
 
 var f = function() {
-	return h;
+  return h;
 };
 
 f();

--- a/sbt-plugins/sbt-shared-ui/example/ui1/src/main/assets/less/main.less
+++ b/sbt-plugins/sbt-shared-ui/example/ui1/src/main/assets/less/main.less
@@ -1,0 +1,6 @@
+@bg-color: blue;
+
+body {
+  background-color: @bg-color;
+  border: 1px solid black;
+}

--- a/sbt-plugins/sbt-shared-ui/example/ui1/src/main/public/index.html
+++ b/sbt-plugins/sbt-shared-ui/example/ui1/src/main/public/index.html
@@ -1,10 +1,11 @@
 <html>
 
-	<head>
-		<script src="/public/js/main.js" type="text/javascript"></script>
-	</head>
-	<body>
-		<h1>Hi from UI1</h1>
-	</body>
+  <head>
+    <script src="/assets/js/ui1.js" type="text/javascript"></script>
+    <link href="/assets/less/main.css" rel="stylesheet">
+  </head>
+  <body>
+    <h1>Hi from UI1</h1>
+  </body>
 
 </html>

--- a/sbt-plugins/sbt-shared-ui/src/main/scala/SharedUiPlugin.scala
+++ b/sbt-plugins/sbt-shared-ui/src/main/scala/SharedUiPlugin.scala
@@ -22,6 +22,7 @@ object SharedUiPlugin extends Plugin {
 
   val defaults = Seq(
     SharedUiKeys.lessFilter := None,
+    (copyResources in WebKeys.Assets) <<= (copyResources in WebKeys.Assets).dependsOn(LessPlugin.LessKeys.less in WebKeys.Assets),
     (LessPlugin.LessKeys.lessFilter in WebKeys.Assets) := {
       SharedUiKeys.lessFilter.value match {
         case Some(filter) => filter


### PR DESCRIPTION
LESS output files were being compiled after managed resources were copied from web assets. This fix ensures the less output files are picked up on first pass instead of second.

The only real code change is in sbt-plugins/sbt-shared-ui/src/main/scala/SharedUiPlugin.scala

@schmmd or @jkinkead take a look?
