### PR TITLE
Forces (for real this time) asset compiling in shared project in test

### DIFF
--- a/sbt-plugins/sbt-shared-ui/example/build.sbt
+++ b/sbt-plugins/sbt-shared-ui/example/build.sbt
@@ -42,7 +42,7 @@ lazy val ui2 = project.in(file("ui2"))
   .settings(SharedUiPlugin.uses(shared): _*)
   .settings(serverSettings: _*)
 
-lazy val root = project.in(file(".")).aggregate(ui1, ui2).settings(
+lazy val root = project.in(file(".")).aggregate(ui1, ui2, shared).settings(
   name := "sbt-shared-ui-tester",
   description := "Proof of technology project for the sbt-shared-ui plugin"
 )

--- a/sbt-plugins/sbt-shared-ui/example/project/plugins.sbt
+++ b/sbt-plugins/sbt-shared-ui/example/project/plugins.sbt
@@ -12,4 +12,4 @@ resolvers += "AllenAI Snapshots" at nexus("snapshots")
 
 resolvers += "AllenAI Releases" at nexus("releases")
 
-addSbtPlugin("org.allenai.plugins" % "sbt-shared-ui" % "2014.2.18-2")
+addSbtPlugin("org.allenai.plugins" % "sbt-shared-ui" % "2014.2.18-3-SNAPSHOT")

--- a/sbt-plugins/sbt-shared-ui/example/shared/src/main/assets/less/colors.less
+++ b/sbt-plugins/sbt-shared-ui/example/shared/src/main/assets/less/colors.less
@@ -1,2 +1,3 @@
 @bg-color: #ccc;
 @color: rgba(200, 50, 0, 0.5);
+@foo-color: blue;

--- a/sbt-plugins/sbt-shared-ui/example/ui1/src/main/assets/less/main.less
+++ b/sbt-plugins/sbt-shared-ui/example/ui1/src/main/assets/less/main.less
@@ -1,4 +1,6 @@
-@bg-color: blue;
+@import "../../../../target/public/foo/less/colors.less";
+
+@bg-color: yellow;
 
 body {
   background-color: @bg-color;

--- a/sbt-plugins/sbt-shared-ui/src/main/scala/SharedUiPlugin.scala
+++ b/sbt-plugins/sbt-shared-ui/src/main/scala/SharedUiPlugin.scala
@@ -66,7 +66,8 @@ object SharedUiPlugin extends Plugin {
       copyWebResources(baseDirectories, newBase)
     },
     resourceGenerators in Compile <+= generateWebResources,
-    (compile in Compile) <<= (compile in Compile).dependsOn(compile in Compile in sharedProject))
+    (compile in Compile) <<= (compile in Compile).dependsOn(compile in Compile in sharedProject),
+    (test in Test) <<= (test in Test).dependsOn(compile in Compile in sharedProject))
 
   /** Helper that walks the directory tree and returs list of files only */
   private def filesOnly(source: File): Seq[File] =


### PR DESCRIPTION
@schmmd please review this. It is blocking https://github.com/allenai/ari-core/pull/222

This solves an issue where importing a LESS file from a shared project would work in production but cause compilation to fail during an `sbt clean test` run, which is why https://github.com/allenai/ari-core/pull/222 build is failing. For example:

``` less
@import "../../../../target/public/shared/main.less";
// some styling here
```

would compile fine, but would fail during `sbt test` because the `target/public/shared` folder hadn't been generated.

The only real change in this preq to fix the bug is adding one setting to UI projects:

``` scala
(test in Test) <<= (test in Test).dependsOn(compile in Compile in sharedProject))
```

which forces the generation of the shared assets in the `target/public/shared` directory.

All the remaining changes are in the example project I use for testing. Changes were necessary to reproduce the bug.
