### PR TITLE
Fixes regression in Less compilation timing

### DIFF
--- a/sbt-plugins/sbt-shared-ui/example/project/plugins.sbt
+++ b/sbt-plugins/sbt-shared-ui/example/project/plugins.sbt
@@ -12,4 +12,4 @@ resolvers += "AllenAI Snapshots" at nexus("snapshots")
 
 resolvers += "AllenAI Releases" at nexus("releases")
 
-addSbtPlugin("org.allenai.plugins" % "sbt-shared-ui" % "2014.2.19-2-SNAPSHOT")
+addSbtPlugin("org.allenai.plugins" % "sbt-shared-ui" % "2014.2.20-1-SNAPSHOT")

--- a/sbt-plugins/sbt-shared-ui/example/shared/src/main/assets/less/shared.less
+++ b/sbt-plugins/sbt-shared-ui/example/shared/src/main/assets/less/shared.less
@@ -3,4 +3,8 @@
 body {
   background-color: @bg-color;
   color: @color;
+
+  h1.shared-h1 {
+    color: blue;
+  }
 }

--- a/sbt-plugins/sbt-shared-ui/example/ui1/src/main/assets/less/main.less
+++ b/sbt-plugins/sbt-shared-ui/example/ui1/src/main/assets/less/main.less
@@ -1,8 +1,8 @@
-@import "../../../../target/public/foo/less/colors.less";
+@import "../../../../target/public/foo/less/shared.less";
 
 @bg-color: yellow;
 
 body {
   background-color: @bg-color;
-  border: 1px solid black;
+  border: 5px solid black;
 }

--- a/sbt-plugins/sbt-shared-ui/example/ui1/src/main/public/index.html
+++ b/sbt-plugins/sbt-shared-ui/example/ui1/src/main/public/index.html
@@ -5,7 +5,7 @@
     <link href="/assets/less/main.css" rel="stylesheet">
   </head>
   <body>
-    <h1>Hi from UI1</h1>
+    <h1 class="shared-h1">Hi from UI1</h1>
   </body>
 
 </html>

--- a/sbt-plugins/sbt-shared-ui/src/main/scala/SharedUiPlugin.scala
+++ b/sbt-plugins/sbt-shared-ui/src/main/scala/SharedUiPlugin.scala
@@ -32,6 +32,7 @@ object SharedUiPlugin extends Plugin {
   /** bases Less CSS settings to be applied to all UI projects */
   private val lessBaseSettings = LessPlugin.lessSettings ++ Seq(
     SharedUiKeys.lessFilter := None,
+    copyResources in WebKeys.Assets <<= (copyResources in WebKeys.Assets).dependsOn(LessKeys.less in Compile),
     LessKeys.lessFilter := {
       SharedUiKeys.lessFilter.value match {
         case Some(filter) => filter

--- a/sbt-plugins/version.sbt
+++ b/sbt-plugins/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2014.2.19-4-SNAPSHOT"
+version in ThisBuild := "2014.2.20-1-SNAPSHOT"


### PR DESCRIPTION
After the last set of changes, ~reStart was picking up changes from previous compile and not the current compile. This fixes that issue.

@jkinkead take a look?
