### PR TITLE
Fixes compilation error during test

### DIFF
--- a/sbt-plugins/sbt-shared-ui/example/project/plugins.sbt
+++ b/sbt-plugins/sbt-shared-ui/example/project/plugins.sbt
@@ -12,4 +12,4 @@ resolvers += "AllenAI Snapshots" at nexus("snapshots")
 
 resolvers += "AllenAI Releases" at nexus("releases")
 
-addSbtPlugin("org.allenai.plugins" % "sbt-shared-ui" % "2014.2.20-1-SNAPSHOT")
+addSbtPlugin("org.allenai.plugins" % "sbt-shared-ui" % "2014.2.20-2-SNAPSHOT")

--- a/sbt-plugins/sbt-shared-ui/src/main/scala/SharedUiPlugin.scala
+++ b/sbt-plugins/sbt-shared-ui/src/main/scala/SharedUiPlugin.scala
@@ -32,7 +32,7 @@ object SharedUiPlugin extends Plugin {
   /** bases Less CSS settings to be applied to all UI projects */
   private val lessBaseSettings = LessPlugin.lessSettings ++ Seq(
     SharedUiKeys.lessFilter := None,
-    copyResources in WebKeys.Assets <<= (copyResources in WebKeys.Assets).dependsOn(LessKeys.less in Compile),
+    copyResources in WebKeys.Assets <<= (copyResources in WebKeys.Assets).dependsOn(LessKeys.less in WebKeys.Assets),
     LessKeys.lessFilter := {
       SharedUiKeys.lessFilter.value match {
         case Some(filter) => filter
@@ -50,7 +50,6 @@ object SharedUiPlugin extends Plugin {
       copySharedWebResources := Nil,
       generateWebResourcesTask,
       generateWebResources <<= generateWebResources.dependsOn(copyResources in WebKeys.Assets),
-      generateWebResources <<= generateWebResources.dependsOn(copySharedWebResources),
       resourceGenerators in Compile <+= generateWebResources,
       compile in Compile <<= (compile in Compile).dependsOn(generateWebResources)
     )
@@ -69,6 +68,7 @@ object SharedUiPlugin extends Plugin {
         val newBase = (resourceManaged in WebKeys.Assets).value / namespace
         copyWebResources(baseDirectories, newBase)
       },
+      generateWebResources <<= generateWebResources.dependsOn(copySharedWebResources),
       copySharedWebResources <<= copySharedWebResources.dependsOn(compile in Compile in sharedProject)
     )
 

--- a/sbt-plugins/version.sbt
+++ b/sbt-plugins/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2014.2.20-1-SNAPSHOT"
+version in ThisBuild := "2014.2.20-2-SNAPSHOT"


### PR DESCRIPTION
Finally discovered the error only occurred in projects that were not using shared assets from another. Fixed by moving:

``` scala
generateWebResources <<= generateWebResources.dependsOn(copySharedWebResources)
```

from the `lessBaseSettings` to the `uses(sharedProject)` settings.

@schmmd take a look?
