### PR TITLE
Use the configuration in conf/deploy.conf of the working project.

### DIFF
--- a/sbt-plugins/sbt-deploy/version.sbt
+++ b/sbt-plugins/sbt-deploy/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2014.3.14-1-SNAPSHOT"
+version in ThisBuild := "2014.4.10-1-SNAPSHOT"


### PR DESCRIPTION
This change makes a CLI argument and `project.subdirectory` obsolete.
