### PR TITLE
Upgrade sbt-shared-ui to use Typesafe 1.0.0-M2a sbt-web dependencies

### DIFF
--- a/sbt-plugins/project/BuildSettings.scala
+++ b/sbt-plugins/project/BuildSettings.scala
@@ -18,7 +18,7 @@ object BuildSettings {
       //"-target:jvm-1.7",
       "-language:_",
       "-Xlog-reflective-calls"),
-    scalaVersion := "2.10.3",
+    scalaVersion := "2.10.4",
     ScalariformKeys.preferences := ScalariformKeys.preferences.value
       .setPreference(AlignSingleLineCaseStatements, true)
       .setPreference(MultilineScaladocCommentsStartOnFirstLine, true)

--- a/sbt-plugins/project/build.properties
+++ b/sbt-plugins/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.2-M3
+sbt.version = 0.13.5-M2

--- a/sbt-plugins/sbt-shared-ui/README.md
+++ b/sbt-plugins/sbt-shared-ui/README.md
@@ -7,6 +7,12 @@ See the `example` project for detailed usage.
 
 ## Getting Started ##
 
+Currently, due to upstream dependencies, minimum SBT version of 0.13.5-M2 is required.
+
+In `[project root]/project/build.properties`, set the following:
+
+    sbt.version = 0.13.5-M2
+
 To start using the `sbt-shared-ui` plugin, you first must add it as a plugin to your SBT project:
 
 In `[project root]/project/plugins.sbt`, add the following:
@@ -30,16 +36,19 @@ Now you can use the plugin in your build file (either `build.sbt` or `project/Bu
 
 // The shared project (name is arbitrary)
 lazy val sharedUi = project.in(file("shared-ui"))
+  .addSbtPlugins(SbtWeb) // required
   .settings(SharedUiPlugin.uiSettings: _*)
 
 // A UI project that depends on shared
 lazy val frontend = project.in(file("frontend"))
+  .addSbtPlugins(SbtWeb) // required
   .dependsOn(sharedUi)
   .settings(SharedUiPlugin.uiSettings: _*)
   .settings(SharedUiPlugin.uses(sharedUi): _*)
 
 // Another UI project that depends on shared
 lazy val anotherFrontend = project.in(file("another-frontend"))
+  .addSbtPlugins(SbtWeb) // required
   .dependsOn(sharedUi)
   .settings(SharedUiPlugin.uiSettings: _*)
   .settings(SharedUiPlugin.uses(sharedUi): _*)
@@ -98,14 +107,17 @@ In `build.sbt`, you have:
 
 ```scala
 lazy val shared = project.in(file("shared"))
+  .addSbtPlugins(SbtWeb)
   .settings(SharedUiPlugin.uiSettings: _*)
 
 lazy val ui1 = project.in(file("ui1"))
+  .addSbtPlugins(SbtWeb)
   .dependsOn(sharedUi)
   .settings(SharedUiPlugin.uiSettings: _*)
   .settings(SharedUiPlugin.uses(shared): _*)
 
 lazy val ui2 = project.in(file("another-frontend"))
+  .addSbtPlugins(SbtWeb)
   .dependsOn(ui1)
   .settings(SharedUiPlugin.uiSettings: _*)
   .settings(SharedUiPlugin.uses(ui1): _*)

--- a/sbt-plugins/sbt-shared-ui/build.sbt
+++ b/sbt-plugins/sbt-shared-ui/build.sbt
@@ -10,6 +10,8 @@ credentials += Credentials(
 
 resolvers += "AllenAI Releases" at nexus
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-jshint-plugin" % "2014.3.18")
+resolvers += "Typesafe Releases Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-less-plugin" % "2014.3.18")
+addSbtPlugin("com.typesafe.sbt" % "sbt-jshint" % "1.0.0-M2a")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.0.0-M2a")

--- a/sbt-plugins/sbt-shared-ui/example/build.sbt
+++ b/sbt-plugins/sbt-shared-ui/example/build.sbt
@@ -15,6 +15,7 @@ val serverSettings = Revolver.settings ++ Seq(
 // You must add the SharedUiPlugin.uiSettings to a project
 // to enable web asset management (javascript linting, LESS processing, etc.)
 lazy val shared = project.in(file("shared"))
+  .addPlugins(SbtWeb)
   .settings(SharedUiPlugin.uiSettings: _*)
   .settings(
     // Force LESS processing of a single main file.
@@ -28,6 +29,7 @@ lazy val shared = project.in(file("shared"))
 // These settings force building of shared web assets as
 // a dependency for the dependent project's build.
 lazy val ui1 = project.in(file("ui1"))
+  .addPlugins(SbtWeb)
   .dependsOn(shared) // required to enable watching assets in `shared`
   .settings(SharedUiPlugin.uiSettings: _*)
   .settings(SharedUiPlugin.uses(shared): _*)
@@ -36,6 +38,7 @@ lazy val ui1 = project.in(file("ui1"))
 // A UI project that uses another project with a dependency.
 // Illustrates transitive dependecny.
 lazy val ui3 = project.in(file("ui3"))
+  .addPlugins(SbtWeb)
   .dependsOn(ui1)
   .settings(SharedUiPlugin.uiSettings: _*)
   .settings(SharedUiPlugin.uses(ui1): _*)
@@ -43,6 +46,7 @@ lazy val ui3 = project.in(file("ui3"))
 
 // A second UI project that uses the `shared` project's assets
 lazy val ui2 = project.in(file("ui2"))
+  .addPlugins(SbtWeb)
   .dependsOn(shared) // required to enable watching assets in `shared`
   .settings(SharedUiPlugin.uiSettings: _*)
   .settings(SharedUiPlugin.uses(shared): _*)

--- a/sbt-plugins/sbt-shared-ui/example/project/build.properties
+++ b/sbt-plugins/sbt-shared-ui/example/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.2-M3
+sbt.version = 0.13.5-M2

--- a/sbt-plugins/sbt-shared-ui/version.sbt
+++ b/sbt-plugins/sbt-shared-ui/version.sbt
@@ -1,1 +1,1 @@
-version := "2014.3.18-SNAPSHOT"
+version := "2014.4.24-SNAPSHOT"


### PR DESCRIPTION
This PR does the following:
- Removes dependency on our internally published sbt-web plugins in favor of the new milestone releases from Typesafe
- Upgrades SBT version for the `sbt-plugins` project 0.13.5-M2. This is required for the Typesafe milestone release dependencies
- Updates README with SBT version notice
- Bumps version of `sbt-shared-ui` plugin

@schmmd take a look?
