### PR TITLE
(sbt-node-js) bump version of sbt-node-js plugin

### DIFF
--- a/sbt-plugins/sbt-node-js/README.md
+++ b/sbt-plugins/sbt-node-js/README.md
@@ -9,7 +9,7 @@ Add the following to your `project/plugins.sbt`:
 ```
 resolvers += Resolver.sonatypeRepo("snapshots")
 
-addSbtPlugin("org.allenai.plugins" % "sbt-node-js" % "2014-06-19-0-SNAPSHOT")
+addSbtPlugin("org.allenai.plugins" % "sbt-node-js" % "2014-06-23-0-SNAPSHOT")
 ```
 
 Add the setting to your Spray server application's `build.sbt` or `Build.scala`:

--- a/sbt-plugins/sbt-node-js/version.sbt
+++ b/sbt-plugins/sbt-node-js/version.sbt
@@ -1,1 +1,1 @@
-version := "2014.06.19-0-SNAPSHOT"
+version := "2014.06.23-0-SNAPSHOT"


### PR DESCRIPTION
@schmmd take a look?

This is necessary because the previous version was published twice and SBT caching of plugins is unpredictable. This new version ensures that the `clean` task will also clean the NodeJS project.
