### PR TITLE
sbt-node-js plugin bugfixes

### DIFF
--- a/sbt-plugins/sbt-node-js/README.md
+++ b/sbt-plugins/sbt-node-js/README.md
@@ -9,7 +9,7 @@ Add the following to your `project/plugins.sbt`:
 ```
 resolvers += Resolver.sonatypeRepo("snapshots")
 
-addSbtPlugin("org.allenai.plugins" % "sbt-node-js" % "2014-06-23-0-SNAPSHOT")
+addSbtPlugin("org.allenai.plugins" % "sbt-node-js" % "2014-06-24-4-SNAPSHOT")
 ```
 
 Add the setting to your Spray server application's `build.sbt` or `Build.scala`:

--- a/sbt-plugins/sbt-node-js/src/main/scala/NodeJsPlugin.scala
+++ b/sbt-plugins/sbt-node-js/src/main/scala/NodeJsPlugin.scala
@@ -30,6 +30,7 @@ object NodeJsPlugin extends Plugin {
   }
 
   val npmTestTask = test in Npm := {
+    (install in Npm).value
     exec("run test", (npmRoot in Npm).value, (environment in Npm).value)
   }
 
@@ -88,17 +89,26 @@ object NodeJsPlugin extends Plugin {
 
   /** Execute `cmd` with `npm` setting `root` as the working directory */
   private def exec(cmd: String, root: File, env: Map[String, String]) = {
-    Process("command -v npm >/dev/null 2>&1").! match {
-      case 0 => // we're good, npm is installed
-      case _ =>
-        println("'npm' is required. Please install it and add it to your PATH.")
-        throw NpmMissingException
+
+    val isTravis = sys.env.get("TRAVIS") match {
+      case Some(_) => true
+      case None => false
     }
 
-    Process(s"npm ${cmd}", root, env.toSeq: _*).! match {
-      case 0 => // we're good
-      case _ => throw new Exception("failed process call")
+    def npmInstalled = Process("hash npm >/dev/null").! match {
+      case 0 => true
+      case _ => false
+    }
+
+    if (isTravis || npmInstalled) {
+      println(s"Will execute `npm ${cmd}` in file ${root.getAbsolutePath}")
+      Process(s"npm ${cmd}", root, env.toSeq: _*).! match {
+        case 0 => // we're good
+        case _ => throw new Exception(s"Failed process call `npm ${cmd}`")
+      }
+    } else {
+      println("'npm' is required. Please install it and add it to your PATH.")
+      throw NpmMissingException
     }
   }
-
 }

--- a/sbt-plugins/sbt-node-js/version.sbt
+++ b/sbt-plugins/sbt-node-js/version.sbt
@@ -1,1 +1,1 @@
-version := "2014.06.23-0-SNAPSHOT"
+version := "2014.06.24-4-SNAPSHOT"


### PR DESCRIPTION
@schmmd review?

This fixes an issue where checking for `npm` during a Travis build failed. Since Travis guarantees `npm` to be available on all builds, we can just assume `npm` is available when we are in a Travis build (detected via TRAVIS environment variable).

Also, I've added the `npm:install` task as a dependency for the `npm:test` task to force installation of node dependencies prior to running tests.
