### PR TITLE
Remove default setting to have products task depend on npm:build

### DIFF
--- a/sbt-plugins/sbt-node-js/README.md
+++ b/sbt-plugins/sbt-node-js/README.md
@@ -9,7 +9,7 @@ Add the following to your `project/plugins.sbt`:
 ```
 resolvers += Resolver.sonatypeRepo("snapshots")
 
-addSbtPlugin("org.allenai.plugins" % "sbt-node-js" % "2014-06-24-5-SNAPSHOT")
+addSbtPlugin("org.allenai.plugins" % "sbt-node-js" % "2014-06-25-0-SNAPSHOT")
 ```
 
 Add the setting to your Spray server application's `build.sbt` or `Build.scala`:

--- a/sbt-plugins/sbt-node-js/src/main/scala/NodeJsPlugin.scala
+++ b/sbt-plugins/sbt-node-js/src/main/scala/NodeJsPlugin.scala
@@ -69,7 +69,6 @@ object NodeJsPlugin extends Plugin {
     npmInstallTask,
     test in Test <<= (test in Test).dependsOn(test in Npm),
     clean <<= clean.dependsOn(clean in Npm),
-    products in Compile <<= (products in Compile).dependsOn(build in Npm),
     commands += npm)
 
   /** Allows user to execute arbitrary npm command from the SBT console with working directory set to npmRoot */

--- a/sbt-plugins/sbt-node-js/version.sbt
+++ b/sbt-plugins/sbt-node-js/version.sbt
@@ -1,1 +1,1 @@
-version := "2014.06.24-5-SNAPSHOT"
+version := "2014.06.26-0-SNAPSHOT"


### PR DESCRIPTION
This PR removes the default setting that makes `npm:build` a dependency of `compile:products`. This complicates the client usage, but in my opinion is worthwhile because of a gain in flexibility and build performance. Explanation follows...

I originally wanted to minimize the amount of boilerplate build setting code required to use the `sbt-node-js` plugin. One goal was to have the `npm:build` task (the task that causes a production build of the client project) to by default occur prior to application deploy. Unfortunately, it proved difficult to find an appropriate task to hook into without introducing a direct dependency on `sbt-deploy` plugin. I tried `managedResources`, `products`, and `resourceGenerators`. There were tradeoffs for using any of these task hooks. One major tradeoff was that the `npm:build` task was triggered whenever you ran tests, including a `testOnly` task. This slows down the TDD workflow and in my opinion is an unacceptable solution.

So, in this PR I have removed the default setting to trigger `npm:build` altogether. This means that the client project is responsible for specifying when to trigger `npm:build`. The convention, when the client project has a dependency on `sbt-deploy`, should be to trigger a build as a dependency of the `universal:mappings` task:

``` scala
// in build.sbt / Build.scala
mappings in Universal <<- (mappings in Universal).dependsOn(build in Npm)
```

**Note**: I'm thinking that a good general strategy would be to keep individual plugins independent, but then introduce "aggregate" plugins that combine plugins for common application archetypes. For example, we could have a `sbt-allenai-webapp` plugin that aggregates `sbt-deploy` and `sbt-node-js` plugins and set default settings accordingly.
