### PR TITLE
Publish deploy to sonatype; use weird version format to make SBT happy

### DIFF
--- a/sbt-plugins/build.sbt
+++ b/sbt-plugins/build.sbt
@@ -43,6 +43,7 @@ lazy val sbtSharedUi =
 lazy val sbtDeploy =
   project.in(file("sbt-deploy"))
     .settings(sbtPluginSettings: _*)
+    .settings(sonatypePublishSettings: _*)
     .settings(
       name := "sbt-deploy"
     )

--- a/sbt-plugins/sbt-deploy/README.md
+++ b/sbt-plugins/sbt-deploy/README.md
@@ -15,7 +15,7 @@ deploy
 Add the plugin to your project:
 ```
 // In project/plugins.sbt
-addSbtPlugin("org.allenai.plugins" % "sbt-deploy" % "2014.06.26-0-SNAPSHOT")
+addSbtPlugin("org.allenai.plugins" % "sbt-deploy" % "2014.06.26-2l-SNAPSHOT")
 ```
 Enable the deploy plugin, which will provide default settings
 ```

--- a/sbt-plugins/sbt-deploy/version.sbt
+++ b/sbt-plugins/sbt-deploy/version.sbt
@@ -1,1 +1,1 @@
-version := "2014.06.26-1-SNAPSHOT"
+version := "2014.06.26-2l-SNAPSHOT"

--- a/sbt-plugins/sbt-node-js/README.md
+++ b/sbt-plugins/sbt-node-js/README.md
@@ -9,7 +9,7 @@ Add the following to your `project/plugins.sbt`:
 ```
 resolvers += Resolver.sonatypeRepo("snapshots")
 
-addSbtPlugin("org.allenai.plugins" % "sbt-node-js" % "2014.06.26-1-SNAPSHOT")
+addSbtPlugin("org.allenai.plugins" % "sbt-node-js" % "2014.06.26-2l-SNAPSHOT")
 ```
 
 Enable the plugin for your project in `build.sbt`:

--- a/sbt-plugins/sbt-node-js/version.sbt
+++ b/sbt-plugins/sbt-node-js/version.sbt
@@ -1,1 +1,1 @@
-version := "2014.06.26-1-SNAPSHOT"
+version := "2014.06.26-2l-SNAPSHOT"

--- a/sbt-plugins/sbt-webapp/README.md
+++ b/sbt-plugins/sbt-webapp/README.md
@@ -5,7 +5,7 @@ This plugin aggregates the `sbt-deploy` and `sbt-node-js` plugins.
 To use, add the following to your projects `project/plugins.sbt` file:
 
 ```scala
-addSbtPlugin("org.allenai.plugins" % "sbt-webapp" % "2014.06.26-1-SNAPSHOT")
+addSbtPlugin("org.allenai.plugins" % "sbt-webapp" % "2014.06.26-2l-SNAPSHOT")
 ```
 
 The `sbt-webapp` is an [AutoPlugin](http://www.scala-sbt.org/release/tutorial/Using-Plugins.html#Creating+an+auto+plugin), which provides default settings (more on defaults later). You have to enable the plugin for your project. In `build.sbt`:

--- a/sbt-plugins/sbt-webapp/version.sbt
+++ b/sbt-plugins/sbt-webapp/version.sbt
@@ -1,1 +1,1 @@
-version := "2014.06.26-1-SNAPSHOT"
+version := "2014.06.26-2l-SNAPSHOT"


### PR DESCRIPTION
@schmmd this makes deploy publish to Sonatype and modifies the version format of the sbt-webapp plugins to make SBT work.
