### PR TITLE
Ignore overridden methods when complaining about missing return type.

### DIFF
--- a/sbt-style/src/main/resources/allenai-style-config.xml
+++ b/sbt-style/src/main/resources/allenai-style-config.xml
@@ -107,6 +107,9 @@
     </parameters>
   </check>
   <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true">
+    <parameters>
+      <parameter name="ignoreOverride">true</parameter>
+    </parameters>
     <customMessage>Missing return type for public method</customMessage>
   </check>
   <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true">


### PR DESCRIPTION
@markschaake . I thought I had set this, but apparently not.
