### PR TITLE
Add dependencyGraph plugin with sugar from Gilt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,9 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.6.0")
 
 addSbtPlugin("com.danieltrinh" % "sbt-scalariform" % "1.3.0")
 
+// Dependency graph visualiztion in SBT console
+addSbtPlugin("com.gilt" % "sbt-dependency-graph-sugar" % "0.7.4")
+
 // Wrapped by WebServicePlugin and WebappPlugin
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.7.2")
 


### PR DESCRIPTION
@schmmd this adds this nicer version of dependencyGraph:

https://github.com/gilt/sbt-dependency-graph-sugar

Note: this plugin could alternatively be added to your ~/.sbt/0.13/allenai.sbt and would be available to all projects without adding settings (this is what I had set up locally). This is in contrast with [the plugin that this wraps](https://github.com/jrudolph/sbt-dependency-graph) (which is the one you talked about in the engineering meeting).
