### PR TITLE
(WebappPlugin) speed up service dev

### DIFF
--- a/docs/webapp.md
+++ b/docs/webapp.md
@@ -2,7 +2,7 @@
 
 **Requires**: `WebServicePlugin` && `NodeJsPlugin` ([node plugin doc](node-js.md))
 
-The `sbt-webapp` is a superset of the `WebServicePlugin` which adds support for managing a Node.js build from SBT. You enable the plugin for your project. In `build.sbt`:
+The `sbt-webapp` is a superset of the `WebServicePlugin` adding support for managing a Node.js build from SBT. You enable the plugin for your project. In `build.sbt`:
 
 ```scala
 val myProject = project.in(file(".")).enablePlugins(WebappPlugin)
@@ -26,13 +26,27 @@ Additionally, the `sbt-webapp` plugin adds the `buildDir` to the `mappings in Un
 You can change any of the settings for `sbt-node-js` and `sbt-deploy` plugins in the following way:
 
 ```scala
-val myProject = project.in(file("."))
-  .enablePlugins(WebappPlugin)
-  .settings(
-    nodeProjectDir in Npm := file("clientapp"),
-    nodeProjectTarget in Npm := file("client-build"),
-    mappings in Universal += ...
-  )
+// in build.sbt
+enablePlugins(WebappPlugin)
+nodeProjectDir in Npm := file("clientapp")
+nodeProjectTarget in Npm := file("client-build")
+mappings in Universal += ...
 ```
 
 Note: if you change `nodeProjectDirectory`, the `mappings in Universal` will automatically use the overridden value and package it up during deploy.
+
+## Developing with sbt-revolver
+
+The required `WebServicePlugin` includes [`sbt-revolver`](https://github.com/spray/sbt-revolver). For development, you can run the service layer of the web application via:
+
+```shell
+sbt
+> reStart
+```
+
+Running `reStart` will _not_ build the NPM frontend application. However, the `WebappPlugin` provides an additional task that will build the NPM frontend application:
+
+```shell
+sbt
+> reStartWebapp
+```

--- a/src/main/scala/org/allenai/plugins/archetypes/WebappPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/archetypes/WebappPlugin.scala
@@ -23,6 +23,11 @@ object WebappPlugin extends AutoPlugin {
       val logNodeEnvironment = TaskKey[Unit](
         "logNodeEnvironment",
         "Logs the NodeJs build environment to SBT console")
+
+      val reStartWebapp = TaskKey[Unit](
+        "reStartWebapp",
+        "Restarts the service without running npm:build"
+      )
     }
   }
 
@@ -34,15 +39,18 @@ object WebappPlugin extends AutoPlugin {
     log.info(s"[webapp] NODE_ENV = '$env'")
   }
 
+  val reStartWebappTask = WebappKeys.reStartWebapp := {
+    (NodeKeys.build in Npm).value
+    Revolver.reStart.value
+  }
+
   override lazy val projectSettings: Seq[Setting[_]] = Seq(
     logNodeEnvTask,
+    reStartWebappTask,
     UniversalKeys.stage <<= UniversalKeys.stage.dependsOn(WebappKeys.logNodeEnvironment in Webapp),
     NodeKeys.nodeProjectDir in Npm := (baseDirectory in thisProject).value / "webapp",
     // Set NODE_ENV to the deploy target (e.g. 'prod', 'staging', etc.)
     NodeKeys.buildEnvironment in Npm := deployEnvironment.value.getOrElse("sbt-dev"),
-    // Print the node environment on stage
-    // Force npm:build when using sbt-revolver re-start to ensure UI is built
-    Revolver.reStart <<= Revolver.reStart.dependsOn(NodeKeys.build in Npm),
     mappings in Universal <++= (NodeKeys.nodeProjectTarget in Npm) map directory,
     mappings in Universal <<= (mappings in Universal).dependsOn(NodeKeys.build in Npm))
 }

--- a/src/main/scala/org/allenai/plugins/archetypes/WebappPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/archetypes/WebappPlugin.scala
@@ -22,11 +22,12 @@ object WebappPlugin extends AutoPlugin {
     object WebappKeys {
       val logNodeEnvironment = TaskKey[Unit](
         "logNodeEnvironment",
-        "Logs the NodeJs build environment to SBT console")
+        "Logs the NodeJs build environment to SBT console"
+      )
 
       val reStartWebapp = TaskKey[Unit](
         "reStartWebapp",
-        "Restarts the service without running npm:build"
+        "Runs re-volover's reStart after running npm:build"
       )
     }
   }
@@ -52,5 +53,6 @@ object WebappPlugin extends AutoPlugin {
     // Set NODE_ENV to the deploy target (e.g. 'prod', 'staging', etc.)
     NodeKeys.buildEnvironment in Npm := deployEnvironment.value.getOrElse("sbt-dev"),
     mappings in Universal <++= (NodeKeys.nodeProjectTarget in Npm) map directory,
-    mappings in Universal <<= (mappings in Universal).dependsOn(NodeKeys.build in Npm))
+    mappings in Universal <<= (mappings in Universal).dependsOn(NodeKeys.build in Npm)
+  )
 }


### PR DESCRIPTION
Fixes #118 

I thought it made more sense to revert `reStart` to no longer depend on `npm:build` in favor of adding a new task `reStartWebapp` which runs `npm:build` and then `reStart`. This gives the developer the option to either 

1. build and run just the service with `reStart`, or
1. build and run both the service and webapp frontend with `reStartWebapp`