### PR TITLE
Relax conflict manager; add IntegrationTest config by default

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.7
+sbt.version = 0.13.8

--- a/src/main/scala/org/allenai/plugins/CoreDependencies.scala
+++ b/src/main/scala/org/allenai/plugins/CoreDependencies.scala
@@ -69,8 +69,16 @@ trait CoreDependencies {
   val typesafeConfig = "com.typesafe" % "config" % "1.2.1"
 
   // Akka
-  val akkaVersion = "2.3.9"
-  def akkaModule(id: String): ModuleID = "com.typesafe.akka" %% s"akka-$id" % akkaVersion
+
+  val defaultAkkaVersion = "2.3.10"
+
+  /** Generates an akka module dependency
+    * @param id The akka module ID. E.g. `actor` or `cluster`
+    * @param version Specific akka version. Defaults to `defaultAkkaVersion`
+    */
+  def akkaModule(id: String, version: String = defaultAkkaVersion): ModuleID =
+    "com.typesafe.akka" %% s"akka-$id" % version
+
   val akkaActor = akkaModule("actor") exclude ("com.typesafe", "config")
   val akkaLogging = akkaModule("slf4j")
   val akkaTestkit = akkaModule("testkit")

--- a/src/main/scala/org/allenai/plugins/CoreSettingsPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/CoreSettingsPlugin.scala
@@ -19,14 +19,15 @@ object CoreSettingsPlugin extends AutoPlugin {
     val PublishTo = CoreRepositories.PublishTo
   }
 
+  override val projectConfigurations = Seq(Configurations.IntegrationTest)
+
   // These settings will be automatically applied to projects
   override def projectSettings: Seq[Setting[_]] =
-    Seq(
+    Defaults.itSettings ++ Seq(
       fork := true, // Forking for run, test is required sometimes, so fork always.
       scalaVersion := CoreDependencies.defaultScalaVersion,
       scalacOptions ++= Seq("-target:jvm-1.7", "-Xlint", "-deprecation", "-feature"),
       javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
-      conflictManager := ConflictManager.strict,
       resolvers ++= CoreRepositories.Resolvers.defaults,
       dependencyOverrides ++= CoreDependencies.loggingDependencyOverrides,
       dependencyOverrides += "org.scala-lang" % "scala-library" % scalaVersion.value,

--- a/test-projects/test-cli/project/build.properties
+++ b/test-projects/test-cli/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.8

--- a/test-projects/test-core-settings/project/build.properties
+++ b/test-projects/test-core-settings/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.8

--- a/test-projects/test-deploy/project/build.properties
+++ b/test-projects/test-deploy/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.7
+sbt.version = 0.13.8

--- a/test-projects/test-node-js/project/build.properties
+++ b/test-projects/test-node-js/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.7
+sbt.version = 0.13.8

--- a/test-projects/test-release/project/build.properties
+++ b/test-projects/test-release/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.8

--- a/test-projects/test-style/project/build.properties
+++ b/test-projects/test-style/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.7
+sbt.version = 0.13.8

--- a/test-projects/test-web-service/project/build.properties
+++ b/test-projects/test-web-service/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.8

--- a/test-projects/test-webapp/project/build.properties
+++ b/test-projects/test-webapp/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.8


### PR DESCRIPTION
This PR started as just an upgrade of Akka to 2.3.10, and then I decided to throw some more stuff in :)

- Upgrade akka version to 2.3.10
- Extend the `akkaModule` method to take a version override if you don't want the default
- Removed `ConflictManager.strict` from core settings. I thought we had decided to do this a while back, but could be wrong.
- Added `IntegrationTest` config by default to all projects (via `CoreSettings` autoplugin).

@schmmd and / or @jkinkead review?
@dirkgr any concerns with the conflict manager being non-strict (take latest) and our plans to move to semantic versioning?