### PR TITLE
Don't create the Universal start / stop scripts when staging for deploy.

### DIFF
--- a/src/main/scala/org/allenai/plugins/DeployPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/DeployPlugin.scala
@@ -262,6 +262,7 @@ object DeployPlugin extends AutoPlugin {
       throw new IllegalArgumentException("Error running restart command.")
     }
     log.info("")
+    // TODO(jkinkead): Run an automated "/info/name" check here to see if service is running.
     log.info("Deploy complete. Validate your server!")
   }
 
@@ -273,15 +274,16 @@ object DeployPlugin extends AutoPlugin {
       sys.env.get(DeployEnvironment)
     },
     deployTask,
-
-    // TODO(jkinkead): Run an automated "/info/name" check here to see if services are running.
-
     resourceGenerators in Compile <+= generateRunClassTask,
 
     // Add root run script.
     mappings in Universal += {
       (resourceManaged in Compile).value / "run-class.sh" -> "bin/run-class.sh"
     },
+
+    // Don't create garbage start scripts; we use our own wrappers that call run-class.
+    JavaAppPackaging.autoImport.makeBashScript := None,
+    JavaAppPackaging.autoImport.makeBatScript := None,
 
     // Map src/main/resources => conf and src/main/bin => bin.
     // See http://www.scala-sbt.org/0.12.3/docs/Detailed-Topics/Mapping-Files.html

--- a/test-projects/test-deploy/src/main/scala/HelloWorld.scala
+++ b/test-projects/test-deploy/src/main/scala/HelloWorld.scala
@@ -1,0 +1,4 @@
+/** Object with main method, to verify that we don't create the universal start / stop scripts. */
+object HelloWorld extends App {
+  println("Hello, World!")
+}


### PR DESCRIPTION
This is a confusing feature of the packager, especially because these scripts will silently disappear if you have multiple main methods configured.

@afader - I remember you being confused by the random scripts showing up in `bin`.