### PR TITLE
Gulpiness!

### DIFF
--- a/src/main/scala/org/allenai/plugins/NodeJsPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/NodeJsPlugin.scala
@@ -7,9 +7,25 @@ import sbt.inc.Analysis
 // imports standard command parsing functionality
 import complete.DefaultParsers._
 
+import java.lang.{ Runtime => JavaRuntime }
+
+import scala.collection.mutable
+
 /** Plugin that provides an 'npm' command and tasks for test, clean, and build.
   */
 object NodeJsPlugin extends AutoPlugin {
+  private val watches = mutable.Map.empty[ProjectRef, Process]
+  // Set up a shutdown hook to kill any running processes when we exit.
+  JavaRuntime.getRuntime.addShutdownHook(
+    new Thread(new Runnable {
+      override def run(): Unit = {
+        watches.synchronized {
+          watches.values.foreach { _.destroy() }
+          watches.clear()
+        }
+      }
+    })
+  )
 
   object autoImport {
     val Npm = ConfigKey("npm")
@@ -20,6 +36,12 @@ object NodeJsPlugin extends AutoPlugin {
       val install = taskKey[Unit](
         "Execution `npm install` in the Node application directory to install dependencies"
       )
+
+      // Note that this isn't called 'watch' because there's another SBT key with this name and a
+      // different value.
+      val nwatch = taskKey[Unit]("Executes `npm watch` in the Node directory")
+
+      val unwatch = taskKey[Unit]("Kills any background watch in this project")
 
       val nodeProjectDir = settingKey[File](
         "The directory containing the Node application"
@@ -62,6 +84,38 @@ object NodeJsPlugin extends AutoPlugin {
     (nodeProjectTarget in Npm).value.listFiles.toSeq
   }
 
+  val npmWatchTask = nwatch in Npm := {
+    val logger = streams.value.log
+
+    val projectRef = thisProjectRef.value
+    val dir = (nodeProjectDir in Npm).value
+    val env = (environment in Npm).value
+
+    // Check for a running process, and start one if it doesn't exist.
+    val newProcessOption = watches.synchronized {
+      if (!watches.contains(projectRef)) {
+        execInstall(dir, env)
+        val process = fork("run watch", dir, env)
+        watches(projectRef) = process
+        Some(process)
+      } else {
+        logger.info("npm watch already running")
+        None
+      }
+    }
+  }
+
+  val npmUnwatchTask = unwatch in Npm := {
+    val logger = streams.value.log
+    val processOption = watches.synchronized {
+      watches.remove(thisProjectRef.value)
+    }
+    processOption map { process =>
+      logger.info("Killing background 'npm watch' . . .")
+      process.destroy()
+    }
+  }
+
   override def requires: Plugins = plugins.JvmPlugin
 
   /** Settings for a single node project located at `root`
@@ -79,6 +133,8 @@ object NodeJsPlugin extends AutoPlugin {
     npmCleanTask,
     npmBuildTask,
     npmInstallTask,
+    npmWatchTask,
+    npmUnwatchTask,
     commands += npm
   )
 
@@ -130,9 +186,12 @@ object NodeJsPlugin extends AutoPlugin {
     exec("run build", root, env)
   }
 
-  /** Execute `cmd` with `npm` setting `root` as the working directory */
-  private def exec(cmd: String, root: File, env: Map[String, String]): Unit = {
+  // TODO(jkinkead): Make the below take logs instead of prinlning.
 
+  /** Forks and executes `cmd` with `npm` setting `root` as the working directory, returning the
+    * resulting process.
+    */
+  private def fork(cmd: String, root: File, env: Map[String, String]): Process = {
     val isTravis = sys.env.contains("TRAVIS")
 
     def npmInstalled: Boolean = Process("which npm").! match {
@@ -144,13 +203,20 @@ object NodeJsPlugin extends AutoPlugin {
 
     if (isTravis || npmInstalled) {
       println(s"Will execute `npm ${cmd}` in file ${root.getAbsolutePath}")
-      Process(s"npm ${cmd}", root, env.toSeq: _*).! match {
-        case 0 => // we're good
-        case _ => throw new Exception(s"Failed process call `npm ${cmd}`")
-      }
+      Process(s"npm ${cmd}", root, env.toSeq: _*).run()
     } else {
       println("'npm' is required. Please install it and add it to your PATH.")
       throw NpmMissingException
+    }
+  }
+
+  /** Execute `cmd` with `npm` setting `root` as the working directory.
+    * @throws Exception if the process returns an non-zero exit code
+    */
+  private def exec(cmd: String, root: File, env: Map[String, String]): Unit = {
+    fork(cmd, root, env).exitValue() match {
+      case 0 => // we're good
+      case _ => throw new Exception(s"Failed process call `npm ${cmd}`")
     }
   }
 }

--- a/src/main/scala/org/allenai/plugins/archetypes/WebappPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/archetypes/WebappPlugin.scala
@@ -23,8 +23,10 @@ object WebappPlugin extends AutoPlugin {
   override lazy val projectSettings: Seq[Setting[_]] = Seq(
     // Expect the node project in a "webapp" subdirectory.
     NodeKeys.nodeProjectDir in Npm := (baseDirectory in thisProject).value / "webapp",
-    // Force npm:build when using sbt-revolver re-start to ensure UI is built
-    Revolver.reStart <<= Revolver.reStart.dependsOn(NodeKeys.build in Npm),
+    // Run "npm watch" when we run a re-start.
+    Revolver.reStart <<= Revolver.reStart.dependsOn(NodeKeys.nwatch in Npm),
+    // Kill background watches on re-stop.
+    Revolver.reStop <<= Revolver.reStop.dependsOn(NodeKeys.unwatch in Npm),
     // Run client-side tests when tests are run.
     test in Test <<= (test in Test).dependsOn(test in Npm),
     // Clean node files on clean.


### PR DESCRIPTION
So gulpy.

This does what we discussed during lunch: `npm install; npm watch` run before the first `re-start`; subsequent `re-start` calls do nothing.

`re-stop` kills the background watch.