### PR TITLE
Upgrade akka to 2.3.11

### DIFF
--- a/src/main/scala/org/allenai/plugins/CoreDependencies.scala
+++ b/src/main/scala/org/allenai/plugins/CoreDependencies.scala
@@ -70,7 +70,7 @@ trait CoreDependencies {
 
   // Akka
 
-  val defaultAkkaVersion = "2.3.10"
+  val defaultAkkaVersion = "2.3.11"
 
   /** Generates an akka module dependency
     * @param id The akka module ID. E.g. `actor` or `cluster`


### PR DESCRIPTION
Akka release notes here: http://akka.io/news/2015/05/12/akka-2.3.11-released.html

This release fixes an issue experienced by @jkinkead on Aristo which forced him to downgrade back to 2.3.9.