### PR TITLE
Make npm log level configurable; default to 'warn'

### DIFF
--- a/src/main/scala/org/allenai/plugins/DeployPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/DeployPlugin.scala
@@ -127,14 +127,16 @@ object DeployPlugin extends AutoPlugin {
       Def.task {
         NodeJsPlugin.execBuild(
           (NodeKeys.nodeProjectDir in Npm).value,
-          NodeJsPlugin.getEnvironment("dev", (NodeKeys.nodeProjectTarget in Npm).value)
+          NodeJsPlugin.getEnvironment("dev", (NodeKeys.nodeProjectTarget in Npm).value),
+          (NodeKeys.npmLogLevel in Npm).value
         )
       }
     } else {
       Def.task {
         NodeJsPlugin.execBuild(
           (NodeKeys.nodeProjectDir in Npm).value,
-          NodeJsPlugin.getEnvironment("prod", (NodeKeys.nodeProjectTarget in Npm).value)
+          NodeJsPlugin.getEnvironment("prod", (NodeKeys.nodeProjectTarget in Npm).value),
+          (NodeKeys.npmLogLevel in Npm).value
         )
       }
     }

--- a/src/main/scala/org/allenai/plugins/NodeJsPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/NodeJsPlugin.scala
@@ -27,6 +27,9 @@ object NodeJsPlugin extends AutoPlugin {
     })
   )
 
+  // from npm docs https://docs.npmjs.com/misc/config#loglevel
+  val ValidLogLevels = Set("silent", "error", "warn", "http", "info", "verbose", "silly")
+
   object autoImport {
     val Npm = ConfigKey("npm")
 
@@ -55,12 +58,11 @@ object NodeJsPlugin extends AutoPlugin {
 
       val nodeProjectTarget = settingKey[File]("Target directory for Node application build")
 
-      val npmLogLevel = settingKey[String]("Log level for npm commands. Valid levels:`warn`, `info`, `verbose`")
+      val npmLogLevel = settingKey[String](
+        s"""Log level for npm commands. Valid levels are: {${ValidLogLevels.mkString(",")}}"""
+      )
     }
   }
-
-  // from npm docs https://docs.npmjs.com/misc/config#loglevel
-  val ValidLogLevels = Set("silent", "error", "warn", "http", "info", "verbose", "silly")
 
   import autoImport._
   import NodeKeys._

--- a/src/main/scala/org/allenai/plugins/NodeJsPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/NodeJsPlugin.scala
@@ -59,6 +59,9 @@ object NodeJsPlugin extends AutoPlugin {
     }
   }
 
+  // from npm docs https://docs.npmjs.com/misc/config#loglevel
+  val ValidLogLevels = Set("silent", "error", "warn", "http", "info", "verbose", "silly")
+
   import autoImport._
   import NodeKeys._
 
@@ -237,6 +240,10 @@ object NodeJsPlugin extends AutoPlugin {
     * @throws Exception if the process returns an non-zero exit code
     */
   private def exec(cmd: String, root: File, env: Map[String, String], npmLogLevel: String): Unit = {
+    require(
+      ValidLogLevels.contains(npmLogLevel),
+      s"""Invalid npmLogLevel value: $npmLogLevel. Must be one of {${ValidLogLevels.mkString(",")}}"""
+    )
     fork(s"$cmd --loglevel $npmLogLevel", root, env).exitValue() match {
       case 0 => // we're good
       case _ => throw new Exception(s"Failed process call `npm ${cmd}`")

--- a/src/main/scala/org/allenai/plugins/NodeJsPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/NodeJsPlugin.scala
@@ -210,7 +210,7 @@ object NodeJsPlugin extends AutoPlugin {
     // any modules that we no longer use. This is important as it can cause
     // dependency conflicts during npm-install (we've seen this on Shippable, for example).
     exec("prune", root, env, npmLogLevel)
-    exec(s"install", root, env, npmLogLevel)
+    exec("install", root, env, npmLogLevel)
   }
 
   /** Execute the build command with the given root + env.

--- a/test-projects/test-node-js/build.sbt
+++ b/test-projects/test-node-js/build.sbt
@@ -23,4 +23,4 @@ Revolver.settings
 
 NodeKeys.nodeProjectDir in Npm := file("node-app")
 
-NodeKeys.npmLogLevel in Npm := "info"
+NodeKeys.npmLogLevel in Npm := NpmLogLevel.Info

--- a/test-projects/test-node-js/build.sbt
+++ b/test-projects/test-node-js/build.sbt
@@ -15,8 +15,12 @@ libraryDependencies ++= Seq(
 
 // Install the NodeJsPlugin settings, providing the relative client directory path
 
-val tester = project.in(file(".")).enablePlugins(NodeJsPlugin)
-  .settings(
-    NodeKeys.nodeProjectDir in Npm := file("node-app"),
-    products in Compile <<= (products in Compile).dependsOn(NodeKeys.build in Npm))
-  .settings(Revolver.settings: _*)
+enablePlugins(NodeJsPlugin)
+
+products in Compile <<= (products in Compile).dependsOn(NodeKeys.build in Npm)
+
+Revolver.settings
+
+NodeKeys.nodeProjectDir in Npm := file("node-app")
+
+NodeKeys.npmLogLevel in Npm := "info"


### PR DESCRIPTION
@schmmd this makes `npm` log level explicit and configurable. Before, we were using the `--quiet` flag which is an alias to `--loglevel warn`, which didn't actually do anything because default loglevel for npm is `warn`. Now, we can increase verbosity via:

```scala
// build.sbt

npmLogLevel in Npm := NpmLogLevel.Info

// or:
npmLogLevel in Npm := NpmLogLevel.Verbose

// or even:
npmLogLevel in Npm := NpmLogLevel.Silly
```
