### PR TITLE
(CoreSettings) make src/it depend on src/test classpath by default

### DIFF
--- a/src/main/scala/org/allenai/plugins/CoreSettingsPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/CoreSettingsPlugin.scala
@@ -44,7 +44,11 @@ object CoreSettingsPlugin extends AutoPlugin {
     file
   }
 
-  override val projectConfigurations = Seq(Configurations.IntegrationTest)
+  // Add the IntegrationTest config to the project. The `extend(Test)` part makes it so
+  // classes in src/it have a classpath dependency on classes in src/test. This makes
+  // it simple to share common test helper code.
+  // See http://www.scala-sbt.org/release/docs/Testing.html#Custom+test+configuration
+  override val projectConfigurations = Seq(Configurations.IntegrationTest extend (Test))
 
   // These settings will be automatically applied to projects
   override def projectSettings: Seq[Setting[_]] =

--- a/test-projects/test-core-settings/src/it/scala/ASpec.scala
+++ b/test-projects/test-core-settings/src/it/scala/ASpec.scala
@@ -1,0 +1,5 @@
+package test
+
+class ASpec {
+  def sayHiFromShared: Unit = println(SharedTestHelper.sayHi)
+}

--- a/test-projects/test-core-settings/src/test/scala/SharedTestHelper.scala
+++ b/test-projects/test-core-settings/src/test/scala/SharedTestHelper.scala
@@ -1,0 +1,5 @@
+package test
+
+object SharedTestHelper {
+  def sayHi: String = "hi"
+}


### PR DESCRIPTION
While writing tests, we often create some helpers for setting up test cases. These helpers may be useful in integration tests as well as unit tests. Previously, integration tests did not have a classpath dependency on unit test classes. This PR makes it so! Now we can have test helpers in our unit tests that are also available to our integration tests.