### PR TITLE
Update release plugins to the latest version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ AI2 SBT Plugins
 The AI2 SBT plugins are intended to minimize build boilerplate accross projects. It is recommended to only enable "Archetype" plugins, which currently include:
 
 - `CliPlugin` - for command line applications using the [scopt](https://github.com/scopt/scopt) library.
-- `LibraryPlugin` - for libraries to be released / published using our `ReleasePlugin`
+- `LibraryPlugin` - for libraries to be released / published using our `Ai2ReleasePlugin`
 - `WebServicePlugin` - for web service applications built on spray, akka, and spray-json
 - `WebappPlugin` ([docs](docs/webapp.md)) - for web applications that have a service layer and a Node.js built web client.
 
@@ -83,8 +83,6 @@ Where `[API Key]` is the API key for the ai2-dev account (or your account if usi
 4. Click on `API Key` in navigation list
 
 ### Releasing
-
-We dogfood our own `ReleasePlugin` for releasing new plugin versions. To issue a release, do the following:
 
 1. Checkout the `master` branch of the repository
 2. Make sure the upstream-tracking branch is `master` @ allenai/sbt-plugins

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,10 @@
-import bintray.{ Keys => BintrayKeys }
-import bintray.{ Plugin => BintrayPlugin }
-
 libraryDependencies ++= Seq("com.typesafe" % "config" % "1.2.0")
 
 organization := "org.allenai.plugins"
 
 name := "allenai-sbt-plugins"
 
-lazy val ai2Plugins = project.in(file(".")).enablePlugins(ReleasePlugin)
+lazy val ai2Plugins = project.in(file("."))
 
 scalacOptions := Seq(
   "-encoding", "utf8",
@@ -22,11 +19,11 @@ scalaVersion := "2.10.4"
 
 sbtPlugin := true
 
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.2.1")
-
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.0")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
 
 addSbtPlugin(
   ("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.6.0")
@@ -44,12 +41,12 @@ addSbtPlugin("io.spray" % "sbt-revolver" % "0.7.2")
 // Allows us to test our plugins via the sbt-scripted plugin:
 scriptedSettings
 
-BintrayPlugin.bintrayPublishSettings
+// Publication settings.
 
 publishMavenStyle := false
 
-BintrayKeys.repository in BintrayKeys.bintray := "sbt-plugins"
+bintrayRepository := "sbt-plugins"
 
-BintrayKeys.bintrayOrganization in BintrayKeys.bintray := Some("allenai")
+bintrayOrganization := Some("allenai")
 
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html"))

--- a/docs/release.md
+++ b/docs/release.md
@@ -21,7 +21,7 @@ For an example, please look at [common](https://github.com/allenai/common).
 Enable the plugin for your **root** project in `build.sbt`:
 
 ```scala
-val myProject = project.in(file(".")).enablePlugins(ReleasePlugin)
+val myProject = project.in(file(".")).enablePlugins(Ai2ReleasePlugin)
 ```
 
 **NOTE FOR OLDER PROJECTS**: If you're migrating an older project (one using a date-based versioning
@@ -29,7 +29,7 @@ scheme), you'll also need to update your `version.sbt` file to contain a semanti
 
 ### Multi-project builds
 If your project consists of subprojects, you must create an aggregate project that:
-- has the `ReleasePlugin` enabled
+- has the `Ai2ReleasePlugin` enabled
 - has stubbed-out publishing settings
 - aggregates all subprojects that will be released
 
@@ -40,7 +40,7 @@ lazy val releaseProject = project.in(file(".")).settings(
     publish := { },
     publishTo := Some("bogus" at "http://nowhere.com"),
     publishLocal := { })
-   .enablePlugins(ReleasePlugin)
+   .enablePlugins(Ai2ReleasePlugin)
    .aggregate(api)
 
 // The project you wish to release

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,6 @@
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.2.1")
-
-// This is required until our allenai-sbt-plugins is added
-// to https://bintray.com/sbt/sbt-plugin-releases (request pending)
-resolvers += Resolver.url("bintray-allenai-sbt-plugin-releases",
-  url("http://dl.bintray.com/content/allenai/sbt-plugins"))(Resolver.ivyStylePatterns)
-
-addSbtPlugin("org.allenai.plugins" % "allenai-sbt-plugins" % "2015.02.16-0")
+// These should match the version in build.sbt.
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 
 // for testing sbt plugins:
 libraryDependencies <+= (sbtVersion) { sv =>

--- a/src/main/scala/org/allenai/plugins/archetypes/LibraryPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/archetypes/LibraryPlugin.scala
@@ -1,10 +1,10 @@
 package org.allenai.plugins.archetypes
 
 import org.allenai.plugins.CoreSettingsPlugin
-import org.allenai.plugins.ReleasePlugin
+import org.allenai.plugins.Ai2ReleasePlugin
 
 import sbt.{ AutoPlugin, Plugins }
 
 object LibraryPlugin extends AutoPlugin {
-  override def requires: Plugins = CoreSettingsPlugin && ReleasePlugin
+  override def requires: Plugins = CoreSettingsPlugin && Ai2ReleasePlugin
 }

--- a/test-projects/test-release/build.sbt
+++ b/test-projects/test-release/build.sbt
@@ -1,3 +1,3 @@
-val test = project.in(file(".")).enablePlugins(ReleasePlugin)
+val test = project.in(file(".")).enablePlugins(Ai2ReleasePlugin)
 
 publishTo := Some("foo" at "bar")

--- a/test-projects/test-release/version.sbt
+++ b/test-projects/test-release/version.sbt
@@ -1,1 +1,1 @@
-version := "2014.07.02-SNAPSHOT"
+version := "1.1.1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2015.06.19-1-SNAPSHOT"
+version in ThisBuild := "0.0.1"


### PR DESCRIPTION
Remove dependency on ai2 plugins.

Note that I had to rename the release plugin, because it conflicted with the auto-imported `ReleasePlugin`.