### PR TITLE
Add a function to get settings to disable bintray.

### DIFF
--- a/src/main/scala/org/allenai/plugins/Ai2ReleasePlugin.scala
+++ b/src/main/scala/org/allenai/plugins/Ai2ReleasePlugin.scala
@@ -84,6 +84,17 @@ object Ai2ReleasePlugin extends AutoPlugin {
     st
   }
 
+  object autoImport {
+    /** Disable Bintray's publication tasks. These settings should be used if you're publishing to a
+      * non-Bintray location.
+      */
+    def disableBintray(): Seq[Def.Setting[_]] = Seq(
+      BintrayKeys.bintrayRelease := {},
+      BintrayKeys.bintrayEnsureBintrayPackageExists := {},
+      BintrayKeys.bintrayEnsureLicenses := {}
+    )
+  }
+
   override lazy val projectSettings: Seq[Def.Setting[_]] = {
     SemanticVersion.settings ++ Seq(
       BintrayKeys.bintrayRepository in ThisBuild := "maven",

--- a/test-projects/test-release/build.sbt
+++ b/test-projects/test-release/build.sbt
@@ -1,3 +1,5 @@
 val test = project.in(file(".")).enablePlugins(Ai2ReleasePlugin)
 
 publishTo := Some("foo" at "bar")
+
+disableBintray()


### PR DESCRIPTION
Autoplugins confuse me. Apparently, just having the bintray plugin on the classpath installs it - which makes anything trying to publish to nexus kinda break (see [this semaphore log](https://semaphoreci.com/allenai/extraction/branches/master/builds/7) for an example). I say "kinda" break, because publication itself actually succeeds - sbt just reports a failure. That's probably a bug in the bintray plugin.

Anyway, this just adds a function you can call to remove the problematic Bintray tasks.