### PR TITLE
Fix the cache key to filter out transitive local project dependencies…

### DIFF
--- a/src/main/scala/org/allenai/plugins/DeployPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/DeployPlugin.scala
@@ -93,7 +93,7 @@ object DeployPlugin extends AutoPlugin {
 
   /** Returns a filter for the local project dependencies. */
   lazy val dependencyFilter: Def.Initialize[Task[ScopeFilter]] = Def.task {
-    val localDependencies = buildDependencies.value.classpathRefs(thisProjectRef.value)
+    val localDependencies = buildDependencies.value.classpathTransitiveRefs(thisProjectRef.value)
     ScopeFilter(inProjects(localDependencies: _*))
   }
 


### PR DESCRIPTION
… instead of just direct local project dependencies.

This fixes the case where we have a complicated local project tree, where a local project is depended on transitively but not directly - something like `frontend` depends on `frontend_api` which depends on `backend_common`.

@ryanai3 - FYI. Oh, the joys of sbt. :)