### PR TITLE
Use latest scalariform and scalastyle releases

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 resolvers += Resolver.jcenterRepo
- 
+
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.2.0",
-  "org.scalatest" %% "scalatest" % "2.2.4" % "test"  
+  "org.scalatest" %% "scalatest" % "2.2.4" % "test"
 )
 
 organization := "org.allenai.plugins"
@@ -31,12 +31,13 @@ addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
 
-addSbtPlugin(
-  ("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.6.0")
-    // Exclude the old scalariform fork - we include a newer version with sbt-scalariform below.
-    .exclude("com.danieltrinh", "scalariform_2.10"))
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0" excludeAll(
+  // scalastyle depends on an old version of scalariform. We bring in the latest with the
+  // sbt-scalariform plugin dependency below.
+  ExclusionRule(organization = "com.danieltrinh")
+))
 
-addSbtPlugin("com.github.jkinkead" % "sbt-scalariform" % "0.1.6")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 
 // Dependency graph visualiztion in SBT console
 addSbtPlugin("com.gilt" % "sbt-dependency-graph-sugar" % "0.7.4")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version = 0.13.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,5 +6,3 @@ addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 libraryDependencies <+= (sbtVersion) { sv =>
   "org.scala-sbt" % "scripted-plugin" % sv
 }
-
-dependencyOverrides += "org.scala-sbt" % "sbt" % "0.13.7"

--- a/src/main/scala/org/allenai/plugins/CoreSettingsPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/CoreSettingsPlugin.scala
@@ -1,15 +1,18 @@
 package org.allenai.plugins
 
-import sbt._
+import com.typesafe.sbt.SbtScalariform
 import sbt.Keys._
+import sbt._
 
+import scalariform.formatter.ScalaFormatter
+import scalariform.formatter.preferences.IFormattingPreferences
 import scalariform.formatter.preferences.{ DoubleIndentClassDeclaration, FormattingPreferences }
-import scalariform.sbt.ScalariformPlugin
+import scalariform.parser.ScalaParserException
 
 object CoreSettingsPlugin extends AutoPlugin {
 
   // Automatically add the StylePlugin and VersionInjectorPlugin
-  override def requires: Plugins = ScalariformPlugin && StylePlugin && VersionInjectorPlugin
+  override def requires: Plugins = SbtScalariform && StylePlugin && VersionInjectorPlugin
 
   // Automatically enable the plugin (no need for projects to `enablePlugins(CoreSettingsPlugin)`)
   override def trigger: PluginTrigger = allRequirements
@@ -21,9 +24,26 @@ object CoreSettingsPlugin extends AutoPlugin {
     val generateRunClass = taskKey[File](
       "creates the run-class.sh script in the managed resources directory"
     )
+
+    val scalariformPreferences = settingKey[IFormattingPreferences](
+      "The Scalariform preferences to use in formatting."
+    )
+
+    val format = taskKey[Seq[File]]("Format all scala source files, returning the changed files")
+
+    val formatCheck = taskKey[Seq[File]](
+      "Check for misformatted scala files, and print out & return those with errors"
+    )
+
+    val formatCheckStrict = taskKey[Unit](
+      "Check for misformatted scala files, print out the names of those with errors, " +
+        "and throw an error if any do have errors"
+    )
   }
 
-  val generateRunClassTask = autoImport.generateRunClass := {
+  import autoImport._
+
+  private val generateRunClassTask = autoImport.generateRunClass := {
     val logger = streams.value.log
     logger.debug("Generating run-class.sh")
     val file = (resourceManaged in Compile).value / "run-class.sh"
@@ -44,6 +64,74 @@ object CoreSettingsPlugin extends AutoPlugin {
     file
   }
 
+  case class FormatResult(sourceFile: File, original: String, formatted: String)
+
+  // Private task implementation for generating output.
+  // Returns FormatResult for all *.scala files in `sourceDirectories`, also honoring the in-scope
+  // `includeFilter` and `excludeFilter`.
+  private val formatInternal = Def.task {
+    val preferences = scalariformPreferences.value
+    // Find all of the scala source files, then run them through scalariform.
+    val sourceFiles = sourceDirectories.value.descendantsExcept(
+      includeFilter.value || "*.scala",
+      excludeFilter.value
+    ).get
+    val scalaMajorVersion = scalaVersion.value.split("-").head
+    for {
+      sourceFile <- sourceFiles
+      original = IO.read(sourceFile)
+      formatted = try {
+        ScalaFormatter.format(original, preferences, scalaVersion = scalaMajorVersion)
+      } catch {
+        // A sclariform parse error generally means a file that won't compile.
+        case e: ScalaParserException =>
+          streams.value.log.error(s"Scalariform parser error in file $sourceFile: ${e.getMessage}")
+          original
+      }
+    } yield FormatResult(sourceFile, original, formatted)
+  }
+
+  val baseScalariformSettings: Seq[Def.Setting[_]] = Seq(
+    format := {
+      // The mainline SbtScalariform uses FileFunction to cache this, but it's not really worth the
+      // effort here - especially given that we actually don't want to cache for formatCheck.
+      for {
+        FormatResult(sourceFile, original, formatted) <- formatInternal.value
+        if original != formatted
+      } yield {
+        // Shorten the name to a friendlier path.
+        val shortName = sourceFile.relativeTo(baseDirectory.value).getOrElse(sourceFile)
+        streams.value.log.info(s"Formatting $shortName . . .")
+        IO.write(sourceFile, formatted)
+        sourceFile
+      }
+    },
+    formatCheck := {
+      val misformatted = for {
+        FormatResult(sourceFile, original, formatted) <- formatInternal.value
+        if original != formatted
+      } yield sourceFile
+
+      if (misformatted.nonEmpty) {
+        val log = streams.value.log
+        log.error("""Some files contain formatting errors; please run "sbt format" to fix.""")
+        log.error("")
+        log.error("Files with errors:")
+        for (result <- misformatted) {
+          // TODO(jkinkead): Log some / all of the diffs?
+          log.error(s"\t$result")
+        }
+      }
+      misformatted
+    },
+    formatCheckStrict := {
+      val misformatted = formatCheck.value
+      if (misformatted.nonEmpty) {
+        throw new MessageOnlyException("Some files have formatting errors.")
+      }
+    }
+  )
+
   // Add the IntegrationTest config to the project. The `extend(Test)` part makes it so
   // classes in src/it have a classpath dependency on classes in src/test. This makes
   // it simple to share common test helper code.
@@ -51,19 +139,41 @@ object CoreSettingsPlugin extends AutoPlugin {
   override val projectConfigurations = Seq(Configurations.IntegrationTest extend (Test))
 
   // These settings will be automatically applied to projects
-  override def projectSettings: Seq[Setting[_]] =
-    Defaults.itSettings ++ Seq(
-      generateRunClassTask,
-      fork := true, // Forking for run, test is required sometimes, so fork always.
-      scalaVersion := CoreDependencies.defaultScalaVersion,
-      scalacOptions ++= Seq("-target:jvm-1.7", "-Xlint", "-deprecation", "-feature"),
-      javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
-      resolvers ++= CoreRepositories.Resolvers.defaults,
-      dependencyOverrides ++= CoreDependencies.loggingDependencyOverrides,
-      dependencyOverrides += "org.scala-lang" % "scala-library" % scalaVersion.value,
-      // Override default scalariform settings.
-      ScalariformPlugin.autoImport.scalariformPreferences := {
-        FormattingPreferences().setPreference(DoubleIndentClassDeclaration, true)
-      }
-    )
+  override def projectSettings: Seq[Setting[_]] = {
+    Defaults.itSettings ++
+      SbtScalariform.defaultScalariformSettingsWithIt ++
+      inConfig(Compile)(baseScalariformSettings) ++
+      inConfig(Test)(baseScalariformSettings) ++
+      inConfig(Configurations.IntegrationTest)(baseScalariformSettings) ++
+      Seq(
+        generateRunClassTask,
+        fork := true, // Forking for run, test is required sometimes, so fork always.
+        scalaVersion := CoreDependencies.defaultScalaVersion,
+        scalacOptions ++= Seq("-target:jvm-1.7", "-Xlint", "-deprecation", "-feature"),
+        javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
+        resolvers ++= CoreRepositories.Resolvers.defaults,
+        dependencyOverrides ++= CoreDependencies.loggingDependencyOverrides,
+        dependencyOverrides += "org.scala-lang" % "scala-library" % scalaVersion.value,
+        // Override default scalariform settings.
+        SbtScalariform.autoImport.scalariformPreferences := {
+          FormattingPreferences().setPreference(DoubleIndentClassDeclaration, true)
+        },
+        // Configure root-level tasks to aggregate accross configs
+        format := {
+          (format in Compile).value
+          (format in Test).value
+          (format in IntegrationTest).value
+        },
+        formatCheck := {
+          (formatCheck in Compile).value
+          (formatCheck in Test).value
+          (formatCheck in IntegrationTest).value
+        },
+        formatCheckStrict := {
+          (formatCheckStrict in Compile).value
+          (formatCheckStrict in Test).value
+          (formatCheckStrict in IntegrationTest).value
+        }
+      )
+  }
 }

--- a/src/main/scala/org/allenai/plugins/CoreSettingsPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/CoreSettingsPlugin.scala
@@ -5,8 +5,7 @@ import sbt.Keys._
 import sbt._
 
 import scalariform.formatter.ScalaFormatter
-import scalariform.formatter.preferences.IFormattingPreferences
-import scalariform.formatter.preferences.{ DoubleIndentClassDeclaration, FormattingPreferences }
+import scalariform.formatter.preferences._
 import scalariform.parser.ScalaParserException
 
 object CoreSettingsPlugin extends AutoPlugin {
@@ -156,7 +155,11 @@ object CoreSettingsPlugin extends AutoPlugin {
         dependencyOverrides += "org.scala-lang" % "scala-library" % scalaVersion.value,
         // Override default scalariform settings.
         SbtScalariform.autoImport.scalariformPreferences := {
-          FormattingPreferences().setPreference(DoubleIndentClassDeclaration, true)
+          FormattingPreferences()
+            .setPreference(DoubleIndentClassDeclaration, true)
+            .setPreference(MultilineScaladocCommentsStartOnFirstLine, true)
+            .setPreference(PlaceScaladocAsterisksBeneathSecondAsterisk, true)
+            .setPreference(SpacesAroundMultiImports, true)
         },
         // Configure root-level tasks to aggregate accross configs
         format := {

--- a/test-projects/test-cli/project/build.properties
+++ b/test-projects/test-cli/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.9

--- a/test-projects/test-core-settings/project/build.properties
+++ b/test-projects/test-core-settings/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.9

--- a/test-projects/test-deploy/project/build.properties
+++ b/test-projects/test-deploy/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version = 0.13.9

--- a/test-projects/test-node-js/project/build.properties
+++ b/test-projects/test-node-js/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version = 0.13.9

--- a/test-projects/test-release/project/build.properties
+++ b/test-projects/test-release/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.9

--- a/test-projects/test-scaladocgen/project/build.properties
+++ b/test-projects/test-scaladocgen/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.9

--- a/test-projects/test-style/project/build.properties
+++ b/test-projects/test-style/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version = 0.13.9

--- a/test-projects/test-style/src/main/scala/Main.scala
+++ b/test-projects/test-style/src/main/scala/Main.scala
@@ -1,6 +1,6 @@
 /** This is the main file for testing the style plugin.  It should generate a few warnings, like this long line. */
 object Main extends App {
   var foo = 100
-  val a  = 1  +  2
+  val a = 1 + 2
   println("foo is " + foo)
 }

--- a/test-projects/test-style/src/test/scala/MainSpec.scala
+++ b/test-projects/test-style/src/test/scala/MainSpec.scala
@@ -1,8 +1,9 @@
 /** This tests that files in test also get their style checked. It should
-  * generate a few warnings. */
+  * generate a few warnings.
+  */
 object MainSpec extends App {
   object fooBar {
-    println("this is "+1)
+    println("this is " + 1)
   }
-  val b  =   1 +   3
+  val b = 1 + 3
 }

--- a/test-projects/test-web-service/project/build.properties
+++ b/test-projects/test-web-service/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.9

--- a/test-projects/test-webapp/project/build.properties
+++ b/test-projects/test-webapp/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.9


### PR DESCRIPTION
- Fixes #192
- Removes dependency on custom scalariform-sbt
- Ported over format, formatCheck, and formatCheckStrict into CoreSettings

Open issues:

- The whitespace-in-comments issue is back with this change. I've verified this is the _only_ functional change by formatting S2 project. We should decide whether this is a deal breaker.

@jkinkead let's discuss