### PR TITLE
Generate autoformatting git pre-commit hook via task

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ object ProjBuild extends Build {
 }
 ```
 
+## Install Git pre-commit hook to autoformat sources
+
+Once you've added the plugins to a project, you can install a git pre-commit hook that will autoformat your code before allowing a commit via:
+
+```shell
+sbt generateAutoformatGitHook
+```
+
 # Developing AI2 Plugins
 
 Currently, all plugins are defined in the same SBT project. New plugins should be created in:

--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,8 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0" excludeAll(
   ExclusionRule(organization = "com.danieltrinh")
 ))
 
+// If you change the scalariform version, you may also need to generate a new
+// scalariform.jar in src/main/resources/autoformat/
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 
 // Dependency graph visualiztion in SBT console

--- a/src/main/resources/autoformat/pre-commit
+++ b/src/main/resources/autoformat/pre-commit
@@ -1,0 +1,91 @@
+#!/bin/sh
+
+# Git pre-commit hook to check staged scala files for formatting issues.
+#
+# This requires that scalariform is installed alongside the pre-commit script, as scalariform.jar.
+# This can be built with "sbt cli/oneJar" - see the README for more details.
+#
+# This script has one gitconfig parameter, hooks.autoformat, which controls how badly-formatted
+# files are handled.
+#
+# Default mode:
+# When autoformat is off, this will test all staged files, and will exit with an error code if any
+# are misformatted, printing the files with errors.
+#
+# Autoformat mode:
+# When autoformat is on, this first checks for unstaged changes to staged files, and if there are
+# any, it will exit with an error. Files with unstaged changes will be printed.
+#
+# If all staged files have no unstaged changes, it will run scalariform against them, leaving the
+# formatting changes unstaged. Changed files will be printed.
+
+# Find all staged scala files, and exit early if there aren't any.
+SCALA_FILES=(`git diff --name-only --cached --diff-filter=AM | grep --color=never '.scala$'`)
+if [ ! "$SCALA_FILES" ]; then
+  exit 0
+fi
+
+# Validate that the scalariform jar exists.
+JAR=`dirname $0`/scalariform.jar
+if [ ! -e $JAR ]; then
+  echo "ERROR: $JAR not found!"
+  exit 2
+fi
+
+# The formatting options we change from the defaults. Values are set by the CoreSettingsPlugin
+# when running generateAutoformatGitHook task.
+OPTIONS=__scalariform_opts__
+
+AUTOFORMAT=$(git config --bool hooks.autoformat)
+
+# Autoformat, if configured to do so.
+if [ "$AUTOFORMAT" != "false" ]; then
+  # Check for unstaged changes to files in the index.
+  CHANGED_FILES=(`git diff --name-only ${SCALA_FILES[@]}`)
+  if [ "$CHANGED_FILES" ]; then
+    echo 'You have unstaged changes to some files in your commit; skipping auto-format.'
+    echo 'Please stage or revert these changes.'
+    echo
+    echo 'Files with unstaged changes:'
+    for file in ${CHANGED_FILES[@]}; do
+      echo "  $file"
+    done
+    exit 1
+  fi
+  # Format all staged files, then exit with an error code if any have uncommitted changes.
+  echo 'Formatting staged scala files . . .'
+  java -jar "$JAR" ${OPTIONS[@]} -q ${SCALA_FILES[@]}
+  CHANGED_FILES=(`git diff --name-only ${SCALA_FILES[@]}`)
+  if [ "$CHANGED_FILES" ]; then
+    echo 'Some staged files were reformatted. Please review the changes and stage them.'
+    echo
+    echo 'Files updated:'
+    for file in ${CHANGED_FILES[@]}; do
+      echo "  $file"
+    done
+    exit 1
+  else
+    exit 0
+  fi
+else
+  echo 'Checking for misformatted scala files . . .'
+  # Get the list of misformatted files.
+  MISFORMATTED=(
+    `java -jar "$JAR" ${OPTIONS[@]} -q --showFilenames -t ${SCALA_FILES[@]} 2>&1`
+  )
+  HAD_ERRORS=$?
+
+  # Print the files, if there are any.
+  if [ $HAD_ERRORS != 0 ]; then
+    echo 'Some staged files contain formatting errors; please run "sbt format" to fix.'
+    echo
+    echo 'Files with errors:'
+    for file in ${MISFORMATTED[@]}; do
+      echo "  $file"
+    done
+    echo
+    exit 1
+  else
+    exit 0
+  fi
+fi

--- a/src/sbt-test/sbt-plugins/simple/test
+++ b/src/sbt-test/sbt-plugins/simple/test
@@ -3,6 +3,7 @@
 $ exec git init
 # Remove any hooks (such as the formatting hook), since it in particular will cause errors.
 $ exec rm -r .git/hooks
+$ exec mkdir .git/hooks
 $ exec git add .
 $ exec git commit -m "initial commit"
 
@@ -31,3 +32,10 @@ $ exists client/node_modules
 $ sleep 2000
 $ exec curl http://0.0.0.0:8888
 > webService/reStop
+
+-$ exists .git/hooks/pre-commit
+-$ exists .git/hooks/scalariform.jar
+
+> generateAutoformatGitHook
+$ exists .git/hooks/pre-commit
+$ exists .git/hooks/scalariform.jar


### PR DESCRIPTION
- Adds an SBT task `generateAutoformatGitHook` that copies scalariform.jar and pre-commit resources from our plugins to the client project's .git/hooks directory.
- Makes sure our scalariform default overrides are consistent between SBT and the commit hook by auto-generating scalariform CLI options
- Fails fast if the user has conflicting files in place
- Added a simple check that the files are generated as expected. I also created a local test project and verified the hooks work. I don't have time right now to add the scripted tests for this - but would be good to add later (that the hooks will cause actual change in format for source files).

@jkinkead and @milescrawford I think this will make onboarding a bit easier. This does not address the "global template" feature, but maybe that is becoming less important as our projects at AI2 as we grow.

@jkinkead could you review?