### PR TITLE
Remove broken project.version logic.

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -53,7 +53,7 @@ You can provide key/value overrides on the commandline through Java-style proper
 
     sbt deploy <target> -Dproperty.path=some_string_value
 
-The override key is within the <target> namespace.  E.g. to set the project version, use `-Dproject.version=`. To set the host use `-Ddeploy.host=`, etc.
+The override key is within the <target> namespace.  E.g. to set the host use `-Ddeploy.host=`, etc.
 
 ### configuration
 Documentation for all of the configuration values is in `conf/global_deploy.conf`, which can serve as a base

--- a/src/main/resources/global_deploy.conf
+++ b/src/main/resources/global_deploy.conf
@@ -11,8 +11,6 @@ project = {
   // The project subdirectory. Optional; if unset, the root directory will be
   // used.
   subdirectory = ${?project.name}
-  // Optional branch / commit / tag to checkout before building.
-  version = null
 }
 deploy = {
   // Hostname to push to. Required.


### PR DESCRIPTION
As discussed offline, the existing support for `project.version` is broken in the plugin because it checks out the specified git commit AFTER staging, and never re-stages. Since we don't plan to use the functionality for our deploys, it's better to just remove it.