### PR TITLE
Add Jedis to core dependencies.

### DIFF
--- a/src/main/scala/org/allenai/plugins/CoreDependencies.scala
+++ b/src/main/scala/org/allenai/plugins/CoreDependencies.scala
@@ -89,6 +89,7 @@ trait CoreDependencies {
   lazy val allenAiWebapp = allenAiCommonModule("webapp")
   lazy val allenAiIndexing = allenAiCommonModule("indexing")
 
+  val jedis = "redis.clients" % "jedis" % "2.7.2"
   val scopt = "com.github.scopt" %% "scopt" % "3.3.0"
   val typesafeConfig = "com.typesafe" % "config" % "1.2.1"
 


### PR DESCRIPTION
Step 1 of centralizing cache usage.