### PR TITLE
Double-escape characters in deploy string to make Scala happy.

### DIFF
--- a/src/main/scala/org/allenai/plugins/DeployPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/DeployPlugin.scala
@@ -739,7 +739,7 @@ object DeployPlugin extends AutoPlugin {
       "-type", "d",
       // Set `find` to only report directories named after this project, with an optional numeric
       // suffix (to avoid stopping other deployed projects).
-      "-regex", s""""./$projectName\(\-[0-9]+\)?"""",
+      "-regex", s""""./$projectName\\(\\-[0-9]+\\)?"""",
       // Within each replica directory meeting the above criteria, stop the service.
       "-exec", s"{}/$stopScriptPath stop \\;"
     )


### PR DESCRIPTION
Sigh.

I verified it actually works when run from Scala and not just the command-line this time.