### PR TITLE
(DeployPlugin) Expose task key for deployNpmBuild

### DIFF
--- a/src/main/scala/org/allenai/plugins/DeployPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/DeployPlugin.scala
@@ -103,6 +103,8 @@ object DeployPlugin extends AutoPlugin {
     // Clients may override to perform a different action in addition to staging (i.e. running
     // database migrations).
     val preDeploy = taskKey[Unit]("Prep the project for a deploy. Defaults to `stageAndCacheKey`.")
+
+    val deployNpmBuild = taskKey[Unit]("Runs the npm build")
   }
 
   import autoImport._
@@ -120,6 +122,7 @@ object DeployPlugin extends AutoPlugin {
     generateEnvConfigTask,
     loadDeployConfigTask,
     nodeEnv := "prod",
+    deployNpmBuild := npmBuildTask.value,
     stageAndCacheKeyTask,
     // By default, this only depends on staging and generating the cache key.
     preDeploy := { stageAndCacheKey.value },

--- a/src/main/scala/org/allenai/plugins/archetypes/WebappPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/archetypes/WebappPlugin.scala
@@ -32,8 +32,10 @@ object WebappPlugin extends AutoPlugin {
     // Clean node files on clean.
     cleanFiles += (NodeKeys.nodeProjectTarget in Npm).value,
     // Build the node project on stage (for deploys).
-    UniversalPlugin.autoImport.stage <<=
-      UniversalPlugin.autoImport.stage.dependsOn(DeployPlugin.npmBuildTask),
+    UniversalPlugin.autoImport.stage := {
+      DeployPlugin.autoImport.deployNpmBuild.value
+      UniversalPlugin.autoImport.stage.value
+    },
     // Copy the built node project into our staging directory, too!
     mappings in Universal <++= (NodeKeys.nodeProjectTarget in Npm) map MappingsHelper.directory
   )

--- a/src/sbt-test/sbt-plugins/simple/build.sbt
+++ b/src/sbt-test/sbt-plugins/simple/build.sbt
@@ -16,10 +16,18 @@ lazy val core = project.in(file("core")).settings(
 
 lazy val cli = project.in(file("cli")).dependsOn(core).enablePlugins(CliPlugin)
 
+lazy val stubbedDeployNpmBuild = taskKey[Unit]("Verify stubbing the deploy npm build works")
+
 lazy val webService = project.in(file("webservice")).dependsOn(core).enablePlugins(WebServicePlugin)
 
 lazy val webApp = project.in(file("webapp")).dependsOn(core).enablePlugins(WebappPlugin)
-  .settings(NodeKeys.nodeProjectDir in Npm := file("client"))
+  .settings(
+    NodeKeys.nodeProjectDir in Npm := file("client"),
+    stubbedDeployNpmBuild := {
+      IO.write(baseDirectory.value / "stubbed.txt", "stubbed")
+      // verify file exists at webapp/stubbed.txt
+    }
+  )
 
 val scalaDocSubProject1 = project.in(file("one"))
 val scalaDocSubProject2 = project.in(file("two"))

--- a/src/sbt-test/sbt-plugins/simple/test
+++ b/src/sbt-test/sbt-plugins/simple/test
@@ -34,6 +34,11 @@ $ exists webapp/public
 $ exists client/build/index.html
 $ exists client/node_modules
 
+# Test it is possible to stub out the deploy NPM build
+> set deployNpmBuild in webApp := (stubbedDeployNpmBuild in webApp).value
+> webApp/stage
+$ exists webapp/stubbed.txt
+
 # WebService plugin tests.
 > webService/reStart
 $ sleep 2000


### PR DESCRIPTION
This enables projects to stub out the NPM build when staging. We need this control for applications in S2 due to bugs in the npm tooling.

@jkinkead please review