### PR TITLE
Remove Nexus and Sonatype resolvers and publish settings.

### DIFF
--- a/src/main/scala/org/allenai/plugins/CoreRepositories.scala
+++ b/src/main/scala/org/allenai/plugins/CoreRepositories.scala
@@ -13,12 +13,8 @@ object CoreRepositories {
 
   /** Common resolvers */
   object Resolvers {
-    private val ai2RepoUrl = "http://utility.allenai.org:8081/nexus/content/repositories"
-
-    val ai2PrivateSnapshots = "AI2 Private Snapshots" at s"${ai2RepoUrl}/snapshots"
-    val ai2PrivateReleases = "AI2 Private Releases" at s"${ai2RepoUrl}/releases"
-    val ai2PublicSnapshots = "AI2 Public Snapshots" at s"${ai2RepoUrl}/public-snapshots"
-    val ai2PublicReleases = "AI2 Public Releases" at s"${ai2RepoUrl}/public-releases"
+    val ai2PrivateReleases = Resolver.bintrayRepo("allenai", "private")
+    val ai2PublicReleases = Resolver.bintrayRepo("allenai", "maven")
 
     // needed for spray-json:
     val spray = "spray" at "http://repo.spray.io/"
@@ -28,8 +24,7 @@ object CoreRepositories {
     val defaults = Seq(
       spray,
       Resolver.jcenterRepo,
-      typesafeReleases,
-      ai2PublicReleases
+      typesafeReleases
     )
   }
 
@@ -37,36 +32,6 @@ object CoreRepositories {
   object PublishTo {
 
     import Resolvers._
-
-    private val sonatypeUrl = "https://oss.sonatype.org"
-
-    private val sonatypeSnapshots = Resolver.sonatypeRepo("snapshots")
-
-    // Cannot use Resolver.sonatypeRepo("releases") here because it
-    // does not point to the correct publishTo repo.
-    private val sonatypeReleases = "Sonatype Releases" at
-      s"${sonatypeUrl}/service/local/staging/deploy/maven2"
-
-    /** Sets publishTo to public Sonatype repo according to isSnapshot value */
-    val sonatype = {
-      publishTo := {
-        if (isSnapshot.value) Some(sonatypeSnapshots) else Some(sonatypeReleases)
-      }
-    }
-
-    /** Sets publishTo to private AI2 repo according to isSnapshot value */
-    val ai2Private = {
-      publishTo := {
-        if (isSnapshot.value) Some(ai2PrivateSnapshots) else Some(ai2PrivateReleases)
-      }
-    }
-
-    /** Sets publishTo to public AI2 repo according to isSnapshot value */
-    val ai2Public = {
-      publishTo := {
-        if (isSnapshot.value) Some(ai2PublicSnapshots) else Some(ai2PublicReleases)
-      }
-    }
 
     /** Sets bintray keys to publish to the private bintray repository. This expects at least one
       * license to be set, e.g. `licenses += Licenses.apache2`.


### PR DESCRIPTION
Nexus and Sonatype are deprecated for publishing.  Future updates should all be published to Bintray.  The removed resolvers can be added in long form to projects that still require them.