### PR TITLE
Use a path relative to `baseDirectory` for docker mappings.

### DIFF
--- a/src/sbt-test/sbt-plugins/simple/docker/build.sbt
+++ b/src/sbt-test/sbt-plugins/simple/docker/build.sbt
@@ -1,8 +1,8 @@
 // Map `foo` in the project root to `bar` in the docker image.
-dockerCopyMappings += (baseDirectory.value / "foo", "bar")
+dockerCopyMappings += (file("foo"), "bar")
 
 // Map src/main/sourcey to `sourcey` in the docker image.
-dockerCopyMappings += (file("sourcey"), "sourcey")
+dockerCopyMappings += (sourceDirectory.value / "main" / "sourcey", "sourcey")
 
 lazy val appendToDockerfile = taskKey[Unit]("append to dockerfile")
 appendToDockerfile := {


### PR DESCRIPTION
Print out a relative path in the helper comment in the generated
Dockerfile.

Fixes #242 .