### PR TITLE
Docker build implementation

### DIFF
--- a/src/main/scala/org/allenai/plugins/DockerBuildPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/DockerBuildPlugin.scala
@@ -302,7 +302,7 @@ $DOCKERFILE_SIGIL
       if (remainder.nonEmpty) {
         remainder.tail.mkString("\n")
       } else {
-        logger.warn(s"Overwriting Dockerfile at $dockerfile . . .")
+        logger.warn(s"Overwriting Dockerfile at $dockerfile...")
         ""
       }
     } else {

--- a/src/main/scala/org/allenai/plugins/DockerBuildPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/DockerBuildPlugin.scala
@@ -179,25 +179,6 @@ object DockerBuildPlugin extends AutoPlugin {
     new File(dockerTargetDir.value, "main")
   }
 
-  /** The location of the staged dependency image's library directory, containing all staged jars.
-    */
-  lazy val dependencyLibDir: Def.Initialize[File] = Def.setting {
-    new File(dependencyImageDir.value, "lib")
-  }
-
-  /** The location of the staged dependency image's Dockerfile. */
-  lazy val dependencyDockerfile: Def.Initialize[File] = Def.setting {
-    new File(dependencyImageDir.value, "Dockerfile")
-  }
-
-  /** The location of the staged dependency image's bin directory, containing the startup script. */
-  lazy val dependencyImageBinDir: Def.Initialize[File] = Def.setting {
-    new File(dependencyImageDir.value, "bin")
-  }
-
-  /** The location of the staged dependency image's startup script. */
-  lazy val dependencyImageStartupScript: Def.Initialize[File] = Def.setting {
-    new File(dependencyImageBinDir.value, STARTUP_SCRIPT_NAME)
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -344,7 +325,7 @@ $DOCKERFILE_SIGIL
     // Create the destination directory.
     val imageDirectory = dependencyImageDir.value
     IO.createDirectory(imageDirectory)
-    val lib = dependencyLibDir.value
+    val lib = new File(dependencyImageDir.value, "lib")
     IO.createDirectory(lib)
 
     // Create the Dockerfile for the dependency image.
@@ -354,14 +335,15 @@ $DOCKERFILE_SIGIL
       |COPY bin bin
       |COPY lib lib
       |""".stripMargin
-    IO.write(dependencyDockerfile.value, dockerfileContents)
+    val dependencyDockerfile = new File(dependencyImageDir.value, "Dockerfile")
+    IO.write(dependencyDockerfile, dockerfileContents)
 
     // Copy the startup script.
-    val bin = dependencyImageBinDir.value
+    val bin = new File(dependencyImageDir.value, "bin")
     if (!bin.exists) {
       IO.createDirectory(bin)
     }
-    val startupScriptDestination = dependencyImageStartupScript.value
+    val startupScriptDestination = new File(bin, STARTUP_SCRIPT_NAME)
     Utilities.copyResourceToFile(getClass, STARTUP_SCRIPT_NAME, startupScriptDestination)
     startupScriptDestination.setExecutable(true)
 

--- a/src/main/scala/org/allenai/plugins/DockerBuildPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/DockerBuildPlugin.scala
@@ -240,7 +240,7 @@ object DockerBuildPlugin extends AutoPlugin {
   /** Task which requires that `docker` exists on the commandline path. */
   lazy val requireDocker: Def.Initialize[Task[Unit]] = Def.task {
     if (Process(Seq("which", "docker")).!(Utilities.NIL_PROCESS_LOGGER) != 0) {
-      sys.error("`docker` not found on path. Please install the docker client before using this.")
+      sys.error("`docker` not found on path. Please install the docker client.")
     }
   }
 


### PR DESCRIPTION
A complete build implementation. I added a `dockerDependencyBuild` because it's nice-to-have for debugging.

Note that I split this into three commits; the first two commits are tiny & might be slightly distracting from the main bit of work.

To get the new image tag to print, you can use the `show` command in sbt:
```
> show dockerBuild
[lots and lots of output]
[info] allenai-docker-private-docker.bintray.io/project/subproject:dc1b889c84ce0960784b0459d6db097e512b060c
[success] Total time: 42 s, completed Nov 4, 2016 3:05:38 PM
>
```