### PR TITLE
Use new name for java base image.

### DIFF
--- a/src/main/scala/org/allenai/plugins/DockerBuildPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/DockerBuildPlugin.scala
@@ -26,7 +26,7 @@ import scala.sys.process.Process
 object DockerBuildPlugin extends AutoPlugin {
   val AI2_PRIVATE_REGISTRY = "allenai-docker-private-docker.bintray.io"
 
-  val DEFAULT_BASE_IMAGE = AI2_PRIVATE_REGISTRY + "/openjdk:8"
+  val DEFAULT_BASE_IMAGE = AI2_PRIVATE_REGISTRY + "/oracle-java:8"
 
   /** The name of the startup script, located in this class's resources. This will also be the name
     * of the script in the `bin` directory in the generated image.


### PR DESCRIPTION
Fixed to use the new name (already in bintray).

After this merges, I'm going to remove the old images (`java`, `openjdk`) from bintray so that they aren't used.