### PR TITLE
Use the correct stop signal by default.

### DIFF
--- a/src/main/scala/org/allenai/plugins/DockerBuildPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/DockerBuildPlugin.scala
@@ -399,6 +399,7 @@ $DOCKERFILE_SIGIL
     val dockerfileContents = s"""
       |FROM ${dockerImageBase.value}
       |WORKDIR ${dockerWorkdir.value}
+      |STOPSIGNAL SIGINT
       |COPY bin bin
       |COPY lib lib
       |""".stripMargin


### PR DESCRIPTION
Hah, forgot to check for this before sending the last one out. I thought I remembered this existing as a Dockerfile option . . .

:)