### PR TITLE
Don't execute `npm install` and `npm prune` with each build.

### DIFF
--- a/src/main/scala/org/allenai/plugins/DeployPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/DeployPlugin.scala
@@ -192,6 +192,7 @@ object DeployPlugin extends AutoPlugin {
       Def.task {
         NodeJsPlugin.execBuild(
           NodeKeys.nodeProjectDir.in(Npm).value,
+          Keys.target.value,
           NodeKeys.buildScripts.in(Npm).value,
           NodeJsPlugin.getEnvironment("dev", NodeKeys.nodeProjectTarget.in(Npm).value),
           NodeKeys.npmLogLevel.in(Npm).value
@@ -201,6 +202,7 @@ object DeployPlugin extends AutoPlugin {
       Def.task {
         NodeJsPlugin.execBuild(
           NodeKeys.nodeProjectDir.in(Npm).value,
+          Keys.target.value,
           NodeKeys.buildScripts.in(Npm).value,
           NodeJsPlugin.getEnvironment("prod", NodeKeys.nodeProjectTarget.in(Npm).value),
           NodeKeys.npmLogLevel.in(Npm).value

--- a/src/main/scala/org/allenai/plugins/archetypes/WebappPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/archetypes/WebappPlugin.scala
@@ -21,8 +21,6 @@ object WebappPlugin extends AutoPlugin {
   override def requires: Plugins = WebServicePlugin && NodeJsPlugin && DeployPlugin
 
   override lazy val projectSettings: Seq[Setting[_]] = Seq(
-    // Expect the node project in a "webapp" subdirectory.
-    NodeKeys.nodeProjectDir.in(Npm) := baseDirectory.in(thisProject).value / "webapp",
     // Run "npm watch" when we run a re-start.
     Revolver.reStart := Revolver.reStart.dependsOn(NodeKeys.nwatch.in(Npm)).evaluated,
     // Kill background watches on re-stop.

--- a/src/sbt-test/sbt-plugins/simple/test
+++ b/src/sbt-test/sbt-plugins/simple/test
@@ -20,13 +20,6 @@ $ exec git commit -m "initial commit"
 > core/styleCheckStrict
 -> core/test:styleCheckStrict
 
-# Node plugin tests.
--$ exists webapp/public
-> webApp/npm:mkNodeTarget
-$ exists webapp/public
-# Second run should not error.
-> webApp/npm:mkNodeTarget
-
 # WebApp plugin tests.
 -$ exists client/build/index.html
 -$ exists client/node_modules


### PR DESCRIPTION
Misc cleanup of node plugin.

This speeds up anything that starts node (`re-start`, `stage`, `dockerBuild`, `dockerRun`).

FYI @cristipp . This change cuts the (cached) webapp build time by several seconds.