### PR TITLE
Automatically log in to ECR if required.

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -279,3 +279,10 @@ Value type: `Boolean`
 Default: `false`
 
 If true, the Dockerfile will be verfied as up-to-date in the `dockerRun` task before the `docker build` command is executed.
+
+### skipEcrLogin
+Value type: `Boolean`
+Default: `false`
+
+If true, the plugin will not attempt an ECR login when an image looks like it's hosted on Amazon
+ECR.


### PR DESCRIPTION
This should ease the transition for people using sbt to build Docker images.

I like that ECR logs people out for security reasons, but I *don't* like the extra work this requires.