### PR TITLE
fixing a typo

### DIFF
--- a/src/main/scala/org/allenai/plugins/DockerBuildPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/DockerBuildPlugin.scala
@@ -903,7 +903,7 @@ $DOCKERFILE_SIGIL
       new File(sourceMain.value, "docker" + File.separatorChar + "Dockerfile")
     },
     dockerCopyMappings := defaultCopyMappings.value,
-    dockerImageRegistryHost := AI2_PRIVATE_REGISTRY,
+    dockerImageRegistryHost := DEFAULT_REGISTRY,
     dockerImageNamePrefix := Keys.organization.value.stripPrefix("org.allenai."),
     dockerImageName := Keys.name.value,
     dockerImageBase := DEFAULT_BASE_IMAGE,


### PR DESCRIPTION
This was revealed when I ran `sbt release`.

After this change, `sbt compile` succeeds. Is that enough testing before `sbt release`?