### PR TITLE
Update DockerBuildPlugin.scala

### DIFF
--- a/src/main/scala/org/allenai/plugins/DockerBuildPlugin.scala
+++ b/src/main/scala/org/allenai/plugins/DockerBuildPlugin.scala
@@ -243,7 +243,7 @@ object DockerBuildPlugin extends AutoPlugin {
     imageName match {
       case IMAGE_REGISTRY(registry) if registry.endsWith(".amazonaws.com") =>
         logger.info("Logging in to ECR...")
-        val command = Seq("bash", "-c", "eval $(aws ecr get-login)")
+        val command = Seq("bash", "-c", "eval $(aws ecr get-login --no-include-email)")
         val result = Process(command).!(Utilities.NIL_PROCESS_LOGGER)
         if (result != 0) {
           logger.warn("Failure logging in to ECR.")


### PR DESCRIPTION
```
(py38) yogic@yogic-thinkpad:~/git/scholar (master) $ bash -c 'eval $(aws ecr get-login)'
unknown shorthand flag: 'e' in -e
See 'docker login --help'.
(py38) yogic@yogic-thinkpad:~/git/scholar (master) $ bash -c 'eval $(aws ecr get-login --no-include-email)'
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
WARNING! Your password will be stored unencrypted in /home/yogic/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded
```